### PR TITLE
Rename nightly builds before compiling instead of after, on Windows.

### DIFF
--- a/Buildcore.pm
+++ b/Buildcore.pm
@@ -1,6 +1,7 @@
 package Buildcore;
 
-# Buildcore plugin for nightly and release build system - common components 1.1.0
+# Buildcore plugin for nightly and release build system - common components 1.2.0
+# 1.2.0 - Stop adding $basename_suffix to all files on Windows; just apply it to the archives.
 # 1.1.0 - Add SHA-256 output and upload for all files within a build, for the Installer.
 # 1.0.1 - MSVC 201x support
 # 1.0.0 - Initial release
@@ -258,7 +259,11 @@ sub move_and_rename
 			$foundext = $1;
 		}
 
-		$newname = $basename . $basename_suffix . $foundext;
+		if ($OS eq "WIN") {
+			$newname = $basename . $foundext;
+		} else {
+			$newname = $basename . $basename_suffix . $foundext;
+		}
 
 		push(@returnfiles, $newname);
 		print "Moving " . $this_build_drop . "/" . $oldname . " to " . $CONFIG->{$OS}->{archive_path} . "/" . $newname . "\n";

--- a/Replacer.pm
+++ b/Replacer.pm
@@ -1,6 +1,7 @@
 package Replacer;
 
-# Replacer Nightlybuild Plugin 1.1
+# Replacer Nightlybuild Plugin 1.2
+# 1.2 - Add support for nightly builds renaming the executable in the project files.
 # 1.1 - Add support for replacing the FS_VERSION_IDENT value when present in versions.
 # 1.0 - Initial release
 
@@ -173,6 +174,18 @@ sub replace_msvc_version
 	$search = "2_open_" . $search;
 	$replace =~ s/[\.\ ]/_/g;
 	$replace = "2_open_" . $replace;
+
+	return ($search, $replace);
+}
+
+sub replace_msvc_version_nightly
+{
+	my $versions_ref = shift;
+	my %versions = %$versions_ref;
+	my $replace = $versions{nextreleaserevision} . "_" . $versions{nextident};
+	my $search = '2_open_(\d_\d_\d\d?(_(AVX|SSE2|SSE))?)';
+	$replace = '2_open_${1}_' . $replace;
+	$raw_regex = 1;
 
 	return ($search, $replace);
 }

--- a/nightlybuild.pl
+++ b/nightlybuild.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -W
 
-# Nightly build script version 3.3.0
+# Nightly build script version 3.4.0
+# 3.4.0 - Rename the executable before compilation instead of after (should result in Nightlies being able to find their symbol files now)
 # 3.3.0 - Add support for replacing the FS_VERSION_IDENT in nightlies
 # 3.2.0 - Use new Mantis module to get number of currently open issues
 # 3.1.0 - Use Buildcore's new SHA-256 support
@@ -73,6 +74,27 @@ my %files = (
 	"code/fred2/fred.rc|raw" => ["inject_revision"],
 	"code/freespace2/freespace.rc|raw" => ["inject_revision"],
 	"code/globalincs/version.h" => ["inject_revision", "inject_ident"],
+	"projects/codeblocks/Freespace2/Freespace2.cbp" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2005/Fred2.vcproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2005/Freespace2.vcproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2005/wxFRED2.vcproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2008/Fred2.vcproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2008/Freespace2.vcproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2010/Fred2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2010/Freespace2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2010/wxFRED2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2012/Fred2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2012/Freespace2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2012/wxFRED2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2013/Fred2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2013/Freespace2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2013/wxFRED2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2015/Fred2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2015/Freespace2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_2015/wxFRED2.vcxproj" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_6/Fred2.dsp" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_6/Freespace2.dsp" => ["replace_msvc_version_nightly"],
+	"projects/MSVC_6/wxFRED2.dsp" => ["replace_msvc_version_nightly"],
 );
 
 my %versions = (


### PR DESCRIPTION
Renaming the executables in the project files means that they should point to the correct symbol file (no need to rename the nightly's .pdb file back to "fs2_open_3_7_3.pdb" to get a usable stack trace).

I've only tested the compilation/archiving part; it's possible I've overlooked something that would break the upload or the forum post.
