### PR TITLE
Update tags when updating the repository

### DIFF
--- a/git.py
+++ b/git.py
@@ -52,6 +52,7 @@ class GitRepository:
 
     def update_repository(self):
         self._git_redirected_success("checkout '{}'".format(self.branch))
+        self._git_redirected_success("fetch --tags origin".format(self.branch))
         self._git_redirected_success("pull origin '{}'".format(self.branch))
 
     def prepare_repo(self):


### PR DESCRIPTION
This should make sure that no tag is missed if the script is run from
two different machines.
