### PR TITLE
Allow script to create nightly posts when a build failed

### DIFF
--- a/forum.py
+++ b/forum.py
@@ -49,7 +49,7 @@ class ForumAPI:
         print("Posting to " + self.config["hlp"]["post_action"].format(board=board))
         return session.post(self.config["hlp"]["post_action"].format(board=board), data=field)
 
-    def post_nightly(self, date, revision, files, log):
+    def post_nightly(self, date, revision, files, log, success):
         print("Posting nightly thread...")
 
         with requests.session() as session:
@@ -65,7 +65,8 @@ class ForumAPI:
                 "date": date,
                 "revision": revision,
                 "files": files,
-                "log": log
+                "log": log,
+                "success": success
             })
 
             print("Creating post...")

--- a/nightly.py
+++ b/nightly.py
@@ -46,7 +46,9 @@ class NightlyState(ScriptState):
         log = self.repo.get_log("nightly_*", self.tag_name)
 
         forum = ForumAPI(self.config)
-        forum.post_nightly(date, commit, files, log)
+        forum.post_nightly(date, commit, files, log, self.success)
+
+        return True
 
     def get_tag_name(self, params):
         return "nightly_{date}_{commit}".format(**params)

--- a/release.py
+++ b/release.py
@@ -41,6 +41,10 @@ class ReleaseState(ScriptState):
         self.version = version
 
     def post_build_actions(self):
+        if not self.success:
+            print("A release build failed to compile!")
+            return False
+
         # Get the file list
         files = github.get_release_files(self.tag_name, config)
 
@@ -51,6 +55,7 @@ class ReleaseState(ScriptState):
         log = self.repo.get_log("nightly_*")
 
         #post_nightly(date, commit, files, log)
+        return True
 
     def get_tag_name(self, params):
         base = "release_{}_{}_{}".format(self.version.major, self.version.minor, self.version.patch)

--- a/script_state.py
+++ b/script_state.py
@@ -68,18 +68,15 @@ class ScriptState:
             # Monitor the created build...
             self.success = build_monitor.monitor_builds(self.tag_name, self.config)
 
-            if not self.success:
-                print("At least one of the builds has failed!")
-                return ScriptState.STATE_FINISHED
-
             return ScriptState.STATE_BUILDS_FINISHED
         elif state == ScriptState.STATE_BUILDS_FINISHED:
             # If the build has just finished then the file hosters may need some time to actually return all the files
             time.sleep(10.)
 
-            self.post_build_actions()
-
-            return ScriptState.STATE_POST_CREATED
+            if self.post_build_actions():
+                return ScriptState.STATE_POST_CREATED
+            else:
+                return ScriptState.STATE_FINISHED
         elif state == ScriptState.STATE_POST_CREATED:
             return ScriptState.STATE_FINISHED
 

--- a/templates/nightly.mako
+++ b/templates/nightly.mako
@@ -1,5 +1,9 @@
 Here is the nightly for ${date} - Revision ${revision}
 
+% if not success:
+[b][color=red]At least one of the nightly builds failed![/color][/b]
+% endif
+
 % for file in files:
 
 Group: ${file["group"]}


### PR DESCRIPTION
A warning will be added to the post but if a few builds have been
compiled then those can be used.
