### PR TITLE
Always reset the config variable to the loaded value

### DIFF
--- a/nightly.py
+++ b/nightly.py
@@ -81,6 +81,8 @@ def main():
             print("State object is not a nightly state! Delete 'state.pickle' or execute right script.")
             return
 
+    # Always use the loaded values to allow changing the config while a script has a serialized state on disk
+    script_state.config = config
     script_state.execute()
 
 

--- a/release.py
+++ b/release.py
@@ -102,6 +102,8 @@ def main():
             print("State object is not a nightly state! Delete 'state.pickle' or execute right script.")
             return
 
+    # Always use the loaded values to allow changing the config while a script has a serialized state on disk
+    script_state.config = config
     script_state.execute()
 
 


### PR DESCRIPTION
There were some issues with changing the config values while the script
state was serialized to disk since the previous config values were
included in that file. This fixes that by always setting the config
field of the script state to the newly loaded config structure.