### PR TITLE
Fix some issues left over from the FTP migration

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -47,5 +47,5 @@ ftp:
     pass: xyz
     path: public_html/builds/{type}/{version}/
     mirrors:
-      - http://scp.indiegames.us/builds/{type}/{version}/{file}
       - http://swc.fs2downloads.com/builds/{type}/{version}/{file}
+      - http://scp.indiegames.us/builds/{type}/{version}/{file}

--- a/templates/nightly.mako
+++ b/templates/nightly.mako
@@ -22,8 +22,6 @@ Group: ${file.group}
 
 % endfor
 
-Download hosting is provided by [url=https://bintray.com/]JFrog Bintray[/url].
-
 [code]
 ${log}
 [/code]


### PR DESCRIPTION
@chief1983 The `config.yml` on the server will need to be updated with the changes in the sample file so that fs2downloads will be the primary file host.