### PR TITLE
Add source code export links to release post

### DIFF
--- a/files.py
+++ b/files.py
@@ -1,9 +1,17 @@
 class ReleaseFile:
-    def __init__(self, name, url, group, subgroup=None, tarball=None, mirrors=[]):
+    def __init__(self, name, url, group, subgroup=None, mirrors=None):
+        if mirrors is None:
+            mirrors = []
         self.mirrors = mirrors
-        self.tarball = tarball
         self.subgroup = subgroup
         self.group = group
         self.url = url
         self.name = name
         self.filename = url.split('/')[-1]
+
+
+class SourceFile:
+    def __init__(self, name, url, group):
+        self.group = group
+        self.url = url
+        self.name = name

--- a/forum.py
+++ b/forum.py
@@ -97,7 +97,7 @@ class ForumAPI:
             print("Creating post...")
             self.create_post(session, title, rendered, self.config["nightly"]["hlp_board"])
 
-    def post_release(self, date, version, files):
+    def post_release(self, date, version, files, sources):
         print("Posting release thread...")
 
         # Construct the file groups
@@ -117,6 +117,7 @@ class ForumAPI:
                 "version": version,
                 "files": files,
                 "groups": groups,
+                "sources": sources
             }).strip("\n")
 
             print("Creating post...")

--- a/release.py
+++ b/release.py
@@ -47,12 +47,12 @@ class ReleaseState(ScriptState):
             return False
 
         # Get the file list
-        files = github.get_release_files(self.tag_name, config)
+        files, sources = github.get_release_files(self.tag_name, config)
 
         date = datetime.datetime.now().strftime("%d %B %Y")
 
         forum = ForumAPI(self.config)
-        forum.post_release(date, self.version, files)
+        forum.post_release(date, self.version, files, sources)
         return True
 
     def get_tag_name(self, params):

--- a/templates/release.mako
+++ b/templates/release.mako
@@ -85,5 +85,7 @@ Alternatively, if there is a package in your software repository then you should
 
 [hidden=Other Platforms, Source Code]
 [color=green][size=12pt]Source Code Export[/size][/color]
-[url=${groups["Win32"].mainFile.tarball}]Source Code[/url]
+[url=${sources["Unix"].url}]Source Code (Unix line endings)[/url]
+
+[url=${sources["Win"].url}]Source Code (Windows line endings)[/url]
 [/hidden]


### PR DESCRIPTION
This requires that scp-fs2open/fs2open.github.com#1421 is merged before
the release is triggered since otherweise there would be no source code
export.