### PR TITLE
Add computation of hashes for release files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 fsobuild/data
 
 **/.cache
+
+state.pickle

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -40,6 +40,7 @@ release:
 templates:
     nightly: templates/nightly.mako
     release: templates/release.mako
+    installer: templates/installer.mako
 
 ftp:
     host: example.com

--- a/files.py
+++ b/files.py
@@ -7,6 +7,8 @@ class ReleaseFile:
         self.group = group
         self.url = url
         self.name = name
+
+        self.base_url = "/".join(url.split('/')[0:-1]) + "/"
         self.filename = url.split('/')[-1]
 
 

--- a/files.py
+++ b/files.py
@@ -11,6 +11,9 @@ class ReleaseFile:
         self.base_url = "/".join(url.split('/')[0:-1]) + "/"
         self.filename = url.split('/')[-1]
 
+        # A list of tuples of (filename, hash)
+        self.content_hashes = None
+
 
 class SourceFile:
     def __init__(self, name, url, group):

--- a/forum.py
+++ b/forum.py
@@ -97,11 +97,8 @@ class ForumAPI:
             print("Creating post...")
             self.create_post(session, title, rendered, self.config["nightly"]["hlp_board"])
 
-    def post_release(self, date, version, files, sources):
+    def post_release(self, date, version, groups, sources):
         print("Posting release thread...")
-
-        # Construct the file groups
-        groups = dict(((x[0], FileGroup(x[0], list(x[1]))) for x in groupby(files, lambda g: g.group)))
 
         with requests.session() as session:
             print("Logging in...")

--- a/forum.py
+++ b/forum.py
@@ -112,7 +112,6 @@ class ForumAPI:
             rendered = template.render(**{
                 "date": date,
                 "version": version,
-                "files": files,
                 "groups": groups,
                 "sources": sources
             }).strip("\n")

--- a/github.py
+++ b/github.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, Dict
+
 import requests
 import re
 
@@ -5,7 +7,7 @@ from files import ReleaseFile
 from files import SourceFile
 
 
-def get_release_files(tag_name, config):
+def get_release_files(tag_name, config) -> Tuple[List[ReleaseFile], Dict[str, SourceFile]]:
     def execute_request(path):
         headers = {
             "Accept": "application/vnd.github.v3+json"

--- a/installer.py
+++ b/installer.py
@@ -5,6 +5,7 @@ from tempfile import NamedTemporaryFile
 from zipfile import ZipFile
 
 import requests
+from mako.template import Template
 
 from files import ReleaseFile
 
@@ -69,17 +70,9 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
         raise NotImplementedError("Unsupported archive type!")
 
 
-def get_installer_config(file: ReleaseFile):
-    lines = [
-        "URL",
-        file.base_url,
-        file.filename
-    ]
-
-    for hash_tuple in get_file_list(file):
-        lines.append("HASH")
-        lines.append("SHA-256")
-        lines.append(hash_tuple[0])
-        lines.append(hash_tuple[1])
-
-    return "\n".join(lines)
+def render_installer_config(version, groups, config):
+    template = Template(filename=config["templates"]["installer"], module_directory='/tmp/mako_modules')
+    return template.render(**{
+        "version": version,
+        "groups": groups,
+    }).strip("\n")

--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,85 @@
+import hashlib
+import tarfile
+import zipfile
+from tempfile import NamedTemporaryFile
+from zipfile import ZipFile
+
+import requests
+
+from files import ReleaseFile
+
+
+def _download_file(url):
+    print("Downloading " + url)
+    local_filename = url.split('/')[-1]
+    # NOTE the stream=True parameter
+    r = requests.get(url, stream=True)
+    with NamedTemporaryFile('wb', delete=False, suffix=local_filename) as f:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:  # filter out keep-alive new chunks
+                f.write(chunk)
+        return f.name
+
+
+def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
+    filename = _download_file(file.url)
+    hash_list = []
+
+    if tarfile.is_tarfile(filename):
+        with tarfile.open(filename) as archive:
+            for entry in archive:
+                if not entry.isfile():
+                    continue
+
+                fileobj = archive.extractfile(entry)
+
+                h = hashlib.new(hash_alg)
+                while True:
+                    data = fileobj.read(4096)
+
+                    if not data:
+                        break
+
+                    h.update(data)
+
+                hash_list.append((entry.path, h.hexdigest()))
+
+            return hash_list
+    elif zipfile.is_zipfile(filename):
+        with ZipFile(filename) as archive:
+            for entry in archive.infolist():
+                # Python 3.6 has is_dir but that version is relatively new so we'll use the "safe" version here
+                if entry.filename.endswith('/'):
+                    continue
+
+                h = hashlib.new(hash_alg)
+                with archive.open(entry) as fileobj:
+                    while True:
+                        data = fileobj.read(4096)
+
+                        if not data:
+                            break
+
+                        h.update(data)
+
+                hash_list.append((entry.filename, h.hexdigest()))
+
+            return hash_list
+    else:
+        raise NotImplementedError("Unsupported archive type!")
+
+
+def get_installer_config(file: ReleaseFile):
+    lines = [
+        "URL",
+        file.base_url,
+        file.filename
+    ]
+
+    for hash_tuple in get_file_list(file):
+        lines.append("HASH")
+        lines.append("SHA-256")
+        lines.append(hash_tuple[0])
+        lines.append(hash_tuple[1])
+
+    return "\n".join(lines)

--- a/release.py
+++ b/release.py
@@ -11,6 +11,7 @@ import semantic_version
 
 import bintray
 import github
+import installer
 from forum import ForumAPI
 from script_state import ScriptState
 
@@ -48,6 +49,10 @@ class ReleaseState(ScriptState):
 
         # Get the file list
         files, sources = github.get_release_files(self.tag_name, config)
+
+        print("Generating installer manifests")
+        for file in files:
+            print(installer.get_installer_config(file))
 
         date = datetime.datetime.now().strftime("%d %B %Y")
 

--- a/script_state.py
+++ b/script_state.py
@@ -70,9 +70,6 @@ class ScriptState:
 
             return ScriptState.STATE_BUILDS_FINISHED
         elif state == ScriptState.STATE_BUILDS_FINISHED:
-            # If the build has just finished then the file hosters may need some time to actually return all the files
-            time.sleep(10.)
-
             if self.post_build_actions():
                 return ScriptState.STATE_POST_CREATED
             else:

--- a/templates/installer.mako
+++ b/templates/installer.mako
@@ -1,0 +1,68 @@
+<%def name="extra_files(platform)">
+URL
+http://www.fsoinstaller.com/files/installer/java/
+mod.ini
+FS2.bmp
+    %if platform == "Win32" or platform == "Win64":
+MULTIURL
+http://scp.fsmods.net/builds/
+http://scp.indiegames.us/builds/
+ENDMULTI
+scptrackir.zip
+HASH
+MD5
+scptrackir.dll
+72a16493f2eccd6e2e389d53e076780b
+HASH
+MD5
+scptrackir64.dll
+044def803cb9795bdc55c6e4e6b619f0
+    %endif
+</%def>
+
+<%def name="sub_group(file)">\
+% if file.subgroup is not None:
+${file.subgroup}\
+%else:
+Standard\
+% endif
+</%def>
+
+<%def name="build(platform, file)">
+NAME
+FreeSpace Open ${version} ${platform} ${sub_group(file)}
+DESC
+${platform} builds for FreeSpace 2 Open.\
+    % if file.subgroup is not None:
+ Compiled with ${file.subgroup} optimizations.
+ENDDESC
+    %else:
+
+ENDDESC
+    % endif
+FOLDER
+/
+URL
+${file.base_url}
+${file.filename}
+    % for filename, hash in file.content_hashes:
+HASH
+SHA-256
+${filename}
+${hash}
+    % endfor
+${extra_files(platform)}
+VERSION
+${version}
+END
+</%def>
+
+% for platform, group in groups.items():
+
+${build(platform, group.mainFile)}
+
+    %for name, subfile in group.subFiles.items():
+${build(platform, subfile)}
+    %endfor
+
+% endfor


### PR DESCRIPTION
This outputs a manifest for each file compatible with the format the
Installer uses so it can be easily copy-pasted to the configuration
file.

At the moment the installer does not accept https as a valid protocol so
that needs to be fixed before the GitHub URLs can be used to download
the files.