### PR TITLE
Automatically add new nightly versions to Nebula package system

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -50,3 +50,7 @@ ftp:
     mirrors:
       - http://swc.fs2downloads.com/builds/{type}/{version}/{file}
       - http://scp.indiegames.us/builds/{type}/{version}/{file}
+
+nebula:
+    user: test
+    password: test

--- a/files.py
+++ b/files.py
@@ -14,6 +14,9 @@ class ReleaseFile:
         # A list of tuples of (filename, hash)
         self.content_hashes = None
 
+        self.hash = None
+        self.size = 0
+
 
 class SourceFile:
     def __init__(self, name, url, group):

--- a/installer.py
+++ b/installer.py
@@ -35,7 +35,7 @@ def _gen_hash(fileobj, hash_alg):
 
 
 def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
-    with NamedTemporaryFile('wb', suffix=file.filename) as local_file:
+    with NamedTemporaryFile('w+b', suffix=file.filename) as local_file:
         _download_file(file.url, local_file)
 
         filename = local_file.name
@@ -43,7 +43,7 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
 
         local_file.seek(0)
         file.hash = _gen_hash(local_file, hash_alg)
-        file.size = os.stat(local_file).st_size
+        file.size = os.stat(filename).st_size
 
         if tarfile.is_tarfile(filename):
             with tarfile.open(filename) as archive:
@@ -51,6 +51,7 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
                     if not entry.isfile():
                         continue
 
+                    print("Computing hash for " + entry.name)
                     fileobj = archive.extractfile(entry)
                     hash_list.append((entry.path, _gen_hash(fileobj, hash_alg)))
         elif zipfile.is_zipfile(filename):
@@ -60,6 +61,7 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
                     if entry.filename.endswith('/'):
                         continue
 
+                    print("Computing hash for " + entry.filename)
                     with archive.open(entry) as fileobj:
                         hash_list.append((entry.filename, _gen_hash(fileobj, hash_alg)))
         else:

--- a/installer.py
+++ b/installer.py
@@ -1,3 +1,4 @@
+import os
 import hashlib
 import tarfile
 import zipfile
@@ -20,12 +21,29 @@ def _download_file(url, dest_file):
     dest_file.flush()
 
 
+def _gen_hash(fileobj, hash_alg):
+    h = hashlib.new(hash_alg)
+    while True:
+        data = fileobj.read(4096)
+
+        if not data:
+            break
+
+        h.update(data)
+
+    return h.hexdigest()
+
+
 def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
     with NamedTemporaryFile('wb', suffix=file.filename) as local_file:
         _download_file(file.url, local_file)
 
         filename = local_file.name
         hash_list = []
+
+        local_file.seek(0)
+        file.hash = _gen_hash(local_file, hash_alg)
+        file.size = os.stat(local_file).st_size
 
         if tarfile.is_tarfile(filename):
             with tarfile.open(filename) as archive:
@@ -34,19 +52,7 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
                         continue
 
                     fileobj = archive.extractfile(entry)
-
-                    h = hashlib.new(hash_alg)
-                    while True:
-                        data = fileobj.read(4096)
-
-                        if not data:
-                            break
-
-                        h.update(data)
-
-                    hash_list.append((entry.path, h.hexdigest()))
-
-                return hash_list
+                    hash_list.append((entry.path, _gen_hash(fileobj, hash_alg)))
         elif zipfile.is_zipfile(filename):
             with ZipFile(filename) as archive:
                 for entry in archive.infolist():
@@ -54,21 +60,12 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
                     if entry.filename.endswith('/'):
                         continue
 
-                    h = hashlib.new(hash_alg)
                     with archive.open(entry) as fileobj:
-                        while True:
-                            data = fileobj.read(4096)
-
-                            if not data:
-                                break
-
-                            h.update(data)
-
-                    hash_list.append((entry.filename, h.hexdigest()))
-
-                return hash_list
+                        hash_list.append((entry.filename, _gen_hash(fileobj, hash_alg)))
         else:
             raise NotImplementedError("Unsupported archive type!")
+
+        file.content_hashes = hash_list
 
 
 def render_installer_config(version, groups, config):

--- a/nebula.py
+++ b/nebula.py
@@ -1,0 +1,154 @@
+import os.path
+import requests
+
+metadata = {
+    'type': 'engine',
+    'title': 'FSO',
+    'notes': '',
+    'banner': 'https://fsnebula.org/storage/0d/e7/bf64bcdea9a9c115969cfb784e1ca457d24a7c2da4fc6f213521c3bb6abb.png',
+    'screenshots': [],
+    'videos': [],
+    'first_release': '2017-09-24',
+    'cmdline': '',
+    'mod_flag': ['FSO'],
+    'tile': 'https://fsnebula.org/storage/ec/cc/0bf23e028c26d5175ff52d003bff85b0a17b0ddfc1130d65bdf6d36f6324.png',
+    'logo': None,
+    'release_thread': None,
+    'description': '',
+    'id': 'FSO'
+}
+
+envs = {
+    'Linux': 'linux && x86_64',  # Linux only has 64bit builds
+    'MacOSX': 'macosx',
+    'Win32': 'windows',
+    'Win64': 'windows && x86_64',
+    'Win32-AVX': 'windows && avx',
+    'Win64-AVX': 'windows && avx && x86_64'
+}
+
+subdirs = {
+    'Win32': 'x86',
+    'Win64': 'x64',
+    'Win32-AVX': 'x86_avx',
+    'Win64-AVX': 'x64_avx'
+}
+
+
+def render_nebula_release(version, files, config):
+    meta = metadata.copy()
+
+    metadata['version'] = version
+
+    for file in files:
+        group = file.group
+
+        if file.subgroup:
+            group += '-' + file.subgroup
+
+        pkg = {
+            'name': group,
+            'notes': '',
+            'is_vp': False,
+            'files': [{
+                'dest': '',
+                'filesize': file.size,
+                'checksum': ['sha256', file.hash],
+                'urls': [file.url] + file.mirrors,
+                'filename': file.name
+            }],
+            'environment': envs.get(group),
+            'filelist': [],
+            'status': 'required',
+            'folder': None,
+            'dependencies': [],
+            'executables': []
+        }
+
+        for fn, checksum in file.content_hashes:
+            if group in subdirs:
+                dest_fn = subdirs[group] + '/' + fn
+            else:
+                dest_fn = fn
+
+            pkg['filelist'].append({
+                'orig_name': fn,
+                'checksum': ('sha256', checksum),
+                'archive': file.name,
+                'filename': dest_fn
+            })
+
+            if group == 'Linux' and fn.endswith('.AppImage'):
+                if '-FASTDBG' in fn:
+                    label = 'Fast Debug'
+                else:
+                    label = None
+
+                pkg['executables'].append({
+                    'file': fn,
+                    'label': label
+                })
+            elif group == 'MacOSX' and fn.startswith(os.path.basename(fn) + '.app/'):
+                if '-FASTDBG' in fn:
+                    label = 'Fast Debug'
+                else:
+                    label = None
+
+                pkg['executables'].append({
+                    'file': fn,
+                    'label': label
+                })
+            elif group.startswith('Win') and fn.endswith('.exe'):
+                if 'fred2' in fn:
+                    if '-FASTDBG' in fn:
+                        label = 'FRED2 Debug'
+                    else:
+                        label = 'FRED2'
+
+                else:
+                    if '-FASTDBG' in fn:
+                        label = 'Fast Debug'
+                    else:
+                        label = None
+
+                pkg['executables'].append({
+                    'file': fn,
+                    'label': label
+                })
+
+    return meta
+
+
+def submit_release(meta, config):
+    with requests.session() as session:
+        print('Logging into Nebula...')
+        result = session.post('https://fsnebula.org/api/1/login', data={
+            'user': config['nebula']['user'],
+            'password': config['nebula']['password']
+        })
+
+        if result.status_code != 200:
+            print('Login failed!')
+            return False
+
+        data = result.json()
+        if not data['result']:
+            print('Login failed!')
+            return False
+
+        print('Submitting release...')
+        result = session.post('https://fsnebula.org/api/1/mod/release', headers={
+            'X-KN-TOKEN': data['token']
+        }, json=meta)
+
+        if result.status_code != 200:
+            print('Request failed!')
+            return False
+
+        data = result.json()
+        if not data['result']:
+            print('ERROR: ' + data['reason'])
+            return False
+
+        print('Success!')
+        return True

--- a/nebula.py
+++ b/nebula.py
@@ -19,6 +19,15 @@ metadata = {
     'packages': [],
 }
 
+platforms = {
+    'Linux': 'linux',
+    'MacOSX': 'macosx',
+    'Win32': 'windows',
+    'Win64': 'windows',
+    'Win32-AVX': 'windows',
+    'Win64-AVX': 'windows'
+}
+
 envs = {
     'Linux': 'linux && x86_64',  # Linux only has 64bit builds
     'MacOSX': 'macosx',
@@ -72,6 +81,10 @@ def render_nebula_release(version, stability, files, config):
                 dest_fn = subdirs[group] + '/' + fn
             else:
                 dest_fn = fn
+
+            # If the group is a known platform then we put the binaries into a separate subfolder for each platform
+            if group in platforms:
+                dest_fn = platforms[group] + '/' + dest_fn
 
             pkg['filelist'].append({
                 'orig_name': fn,

--- a/nebula.py
+++ b/nebula.py
@@ -15,7 +15,8 @@ metadata = {
     'logo': None,
     'release_thread': None,
     'description': '',
-    'id': 'FSO'
+    'id': 'FSO',
+    'packages': [],
 }
 
 envs = {
@@ -37,7 +38,7 @@ subdirs = {
 
 def render_nebula_release(version, stability, files, config):
     meta = metadata.copy()
-    meta['version'] = version
+    meta['version'] = str(version)
     meta['stability'] = stability  # This can be one of ('stable', 'rc', 'nightly')
 
     for file in files:
@@ -86,7 +87,7 @@ def render_nebula_release(version, stability, files, config):
                     label = None
 
                 pkg['executables'].append({
-                    'file': fn,
+                    'file': dest_fn,
                     'label': label
                 })
             elif group == 'MacOSX' and fn.startswith(os.path.basename(fn) + '.app/'):
@@ -96,7 +97,7 @@ def render_nebula_release(version, stability, files, config):
                     label = None
 
                 pkg['executables'].append({
-                    'file': fn,
+                    'file': dest_fn,
                     'label': label
                 })
             elif group.startswith('Win') and fn.endswith('.exe'):
@@ -113,9 +114,11 @@ def render_nebula_release(version, stability, files, config):
                         label = None
 
                 pkg['executables'].append({
-                    'file': fn,
+                    'file': dest_fn,
                     'label': label
                 })
+
+        meta["packages"].append(pkg)
 
     return meta
 

--- a/nebula.py
+++ b/nebula.py
@@ -35,14 +35,15 @@ subdirs = {
 }
 
 
-def render_nebula_release(version, files, config):
+def render_nebula_release(version, stability, files, config):
     meta = metadata.copy()
-
-    metadata['version'] = version
+    meta['version'] = version
+    meta['stability'] = stability  # This can be one of ('stable', 'rc', 'nightly')
 
     for file in files:
         group = file.group
 
+        # release.py sets subgroup but nightly.py doesn't which means we have to normalize group here.
         if file.subgroup:
             group += '-' + file.subgroup
 

--- a/release.py
+++ b/release.py
@@ -54,7 +54,7 @@ class ReleaseState(ScriptState):
 
         print("Generating installer manifests")
         for file in files:
-            file.content_hashes = installer.get_file_list(file)
+            installer.get_file_list(file)
 
         # Construct the file groups
         groups = dict(((x[0], FileGroup(x[0], list(x[1]))) for x in groupby(files, lambda g: g.group)))


### PR DESCRIPTION
These changes will automatically upload the nightly build information to the Nebula package system so Knossos immediately has the newest nightly version available.

Thanks to @ngld for providing the major part of the code needed for adding Nebula support.

@chief1983 This requires some changes to the config file. The sample file contains some example data. For this to work properly you need to use the user "SirKnightly" with the forum password (I also posted this on the internal SCP forum).