### PR TITLE
Avoid a total crash when a file failes to be decompressed

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1,20 +1,22 @@
 import os
 import hashlib
 import tarfile
+import traceback
 import zipfile
 from tempfile import NamedTemporaryFile
 from zipfile import ZipFile
 
 import requests
+import sys
 from mako.template import Template
 
 from files import ReleaseFile
 
 
-def _download_file(url, dest_file):
+def _download_file(url, dest_file, session):
     print("Downloading " + url)
     # NOTE the stream=True parameter
-    r = requests.get(url, stream=True)
+    r = session.get(url, stream=True)
     for chunk in r.iter_content(chunk_size=1024):
         if chunk:  # filter out keep-alive new chunks
             dest_file.write(chunk)
@@ -34,9 +36,12 @@ def _gen_hash(fileobj, hash_alg):
     return h.hexdigest()
 
 
-def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
+def get_file_list(file: ReleaseFile, session: requests.Session = None, hash_alg: str = "sha256"):
+    if session is None:
+        session = requests.Session()
+
     with NamedTemporaryFile('w+b', suffix=file.filename) as local_file:
-        _download_file(file.url, local_file)
+        _download_file(file.url, local_file, session)
 
         filename = local_file.name
         hash_list = []
@@ -45,27 +50,31 @@ def get_file_list(file: ReleaseFile, hash_alg: str = "sha256"):
         file.hash = _gen_hash(local_file, hash_alg)
         file.size = os.stat(filename).st_size
 
-        if tarfile.is_tarfile(filename):
-            with tarfile.open(filename) as archive:
-                for entry in archive:
-                    if not entry.isfile():
-                        continue
+        try:
+            if tarfile.is_tarfile(filename):
+                with tarfile.open(filename) as archive:
+                    for entry in archive:
+                        if not entry.isfile():
+                            continue
 
-                    print("Computing hash for " + entry.name)
-                    fileobj = archive.extractfile(entry)
-                    hash_list.append((entry.path, _gen_hash(fileobj, hash_alg)))
-        elif zipfile.is_zipfile(filename):
-            with ZipFile(filename) as archive:
-                for entry in archive.infolist():
-                    # Python 3.6 has is_dir but that version is relatively new so we'll use the "safe" version here
-                    if entry.filename.endswith('/'):
-                        continue
+                        print("Computing hash for " + entry.name)
+                        fileobj = archive.extractfile(entry)
+                        hash_list.append((entry.path, _gen_hash(fileobj, hash_alg)))
+            elif zipfile.is_zipfile(filename):
+                with ZipFile(filename) as archive:
+                    for entry in archive.infolist():
+                        # Python 3.6 has is_dir but that version is relatively new so we'll use the "safe" version here
+                        if entry.filename.endswith('/'):
+                            continue
 
-                    print("Computing hash for " + entry.filename)
-                    with archive.open(entry) as fileobj:
-                        hash_list.append((entry.filename, _gen_hash(fileobj, hash_alg)))
-        else:
-            raise NotImplementedError("Unsupported archive type!")
+                        print("Computing hash for " + entry.filename)
+                        with archive.open(entry) as fileobj:
+                            hash_list.append((entry.filename, _gen_hash(fileobj, hash_alg)))
+            else:
+                raise NotImplementedError("Unsupported archive type!")
+        except:
+            traceback.print_exception(*sys.exc_info())
+            return
 
         file.content_hashes = hash_list
 

--- a/nebula.py
+++ b/nebula.py
@@ -51,6 +51,10 @@ def render_nebula_release(version, stability, files, config):
     meta['stability'] = stability  # This can be one of ('stable', 'rc', 'nightly')
 
     for file in files:
+        if file.content_hashes is None:
+            # The extraction probably failed which is why we don't have any hashes
+            continue
+
         group = file.group
 
         # release.py sets subgroup but nightly.py doesn't which means we have to normalize group here.


### PR DESCRIPTION
If the decompression fails (e.g. if the file is corrupted) then this
will only print the error to stderr but continue processing the files.
The Nebula information will not contain the invalid file.