### PR TITLE
Store build date in the script state

### DIFF
--- a/nightly.py
+++ b/nightly.py
@@ -71,7 +71,7 @@ class NightlyState(ScriptState):
         for file in files:
             installer.get_file_list(file)
 
-        version = get_source_version(self.config, datetime.datetime.now().strftime("%Y%m%d"))
+        version = get_source_version(self.config, self.date)
         nebula.submit_release(nebula.render_nebula_release(version, "nightly", files, config), config)
 
         commit = self.repo.get_commit()

--- a/script_state.py
+++ b/script_state.py
@@ -29,6 +29,7 @@ class ScriptState:
         self.success = False
         self.state = ScriptState.STATE_INITIAL
         self.repo = git.GitRepository(config["git"]["repo"], config["git"]["branch"])
+        self.date = None
 
     def _go_to_state(self, state):
         """
@@ -46,10 +47,10 @@ class ScriptState:
                 print("Latest commit already has a build tag!")
                 return ScriptState.STATE_FINISHED
 
-            date = datetime.datetime.now().strftime("%Y%m%d")
+            self.date = datetime.datetime.now().strftime("%Y%m%d")
 
             format_args = {
-                "date": date,
+                "date": self.date,
                 "commit": current_commit
             }
 
@@ -57,7 +58,7 @@ class ScriptState:
 
             restore_state = self.repo.prepare_repo()
 
-            self.do_replacements(date, current_commit)
+            self.do_replacements(self.date, current_commit)
 
             self.repo.commit_and_tag(self.tag_name)
 


### PR DESCRIPTION
This will make sure that the date stays consistent if the script is
restarted with a stored script state.