### PR TITLE
Use the stored date for generating the forum post dates

### DIFF
--- a/nightly.py
+++ b/nightly.py
@@ -71,11 +71,11 @@ class NightlyState(ScriptState):
         for file in files:
             installer.get_file_list(file)
 
-        version = get_source_version(self.config, self.date)
+        version = get_source_version(self.config, self.date.strftime(ScriptState.DATEFORMAT_VERSION))
         nebula.submit_release(nebula.render_nebula_release(version, "nightly", files, config), config)
 
         commit = self.repo.get_commit()
-        date = datetime.datetime.now().strftime("%d %B %Y")
+        date = self.date.strftime(ScriptState.DATEFORMAT_FORUM)
         log = self.repo.get_log("nightly_*", self.tag_name)
 
         forum = ForumAPI(self.config)

--- a/release.py
+++ b/release.py
@@ -66,7 +66,7 @@ class ReleaseState(ScriptState):
             nebula.render_nebula_release(self.version, "rc" if self.version.prerelease else "stable", files, config),
             config)
 
-        date = datetime.datetime.now().strftime("%d %B %Y")
+        date = self.date.strftime(ScriptState.DATEFORMAT_FORUM)
 
         forum = ForumAPI(self.config)
         forum.post_release(date, self.version, groups, sources)

--- a/script_state.py
+++ b/script_state.py
@@ -15,6 +15,9 @@ class ScriptState:
     STATE_POST_CREATED = "post_created"
     STATE_FINISHED = "finished"
 
+    DATEFORMAT_VERSION = "%Y%m%d"
+    DATEFORMAT_FORUM = "%d %B %Y"
+
     @staticmethod
     def load_from_file():
         if not os.path.isfile("state.pickle"):
@@ -47,10 +50,10 @@ class ScriptState:
                 print("Latest commit already has a build tag!")
                 return ScriptState.STATE_FINISHED
 
-            self.date = datetime.datetime.now().strftime("%Y%m%d")
+            self.date = datetime.datetime.now()
 
             format_args = {
-                "date": self.date,
+                "date": self.date.strftime(ScriptState.DATEFORMAT_VERSION),
                 "commit": current_commit
             }
 
@@ -58,7 +61,7 @@ class ScriptState:
 
             restore_state = self.repo.prepare_repo()
 
-            self.do_replacements(self.date, current_commit)
+            self.do_replacements(self.date.strftime(ScriptState.DATEFORMAT_VERSION), current_commit)
 
             self.repo.commit_and_tag(self.tag_name)
 


### PR DESCRIPTION
This will allow them to match the build dates.  If I catch that a build error has hung up the process on the day another nightly should have already run, I can fix the currently broken build, it will post with an older date, and then I can re-run the nightly script for the build that should have posted on the current day.  It seems like this has already been working with Nebula so the forum post date is the only thing that needs to change to allow this to not require manual post editing.