### PR TITLE
Use a hard reset to update the script branch

### DIFF
--- a/git.py
+++ b/git.py
@@ -53,7 +53,7 @@ class GitRepository:
     def update_repository(self):
         self._git_redirected_success("checkout '{}'".format(self.branch))
         self._git_redirected_success("fetch --tags origin".format(self.branch))
-        self._git_redirected_success("pull origin '{}'".format(self.branch))
+        self._git_redirected_success("reset --hard 'origin/{}'".format(self.branch))
 
     def prepare_repo(self):
         self._git_redirected_success("checkout '{}'".format(self.branch))


### PR DESCRIPTION
This will make sure that the script still works even if the branch was
force-pushed to a different commit than anticipated.