### PR TITLE
Added missing state to the AppveyorMonitor

### DIFF
--- a/build_monitor/monitors.py
+++ b/build_monitor/monitors.py
@@ -66,10 +66,11 @@ class TravisMonitor(Monitor):
 
 class AppveyorMonitor(Monitor):
     STATUS_QUEUED = "queued"
+    STATUS_STARTING = "starting"
     STATUS_RUNNING = "running"
     STATUS_SUCCESS = "success"
 
-    RUNNING_STATES = [STATUS_QUEUED, STATUS_RUNNING]
+    RUNNING_STATES = [STATUS_QUEUED, STATUS_STARTING, STATUS_RUNNING]
     SUCCESS_STATES = [STATUS_SUCCESS]
 
     def __init__(self, config, tag_name):


### PR DESCRIPTION
This should stop the nightly script from interpreting `starting` as a finished state.