### PR TITLE
Update sample config with datacorder

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -45,8 +45,8 @@ ftp:
     pass: xyz
     path: public_html/builds/{type}/{version}/
     mirrors:
-      - http://swc.fs2downloads.com/builds/{type}/{version}/{file}
       - http://scp.indiegames.us/builds/{type}/{version}/{file}
+      - https://porphyrion.feralhosting.com/datacorder/builds/{type}/{version}/{file}
 
 nebula:
     user: test


### PR DESCRIPTION
Feel like we should keep the sample close to what we actually use, so after we merge the datacorder branch into fs2_open and update the nightlybuild config on the server we can merge this to keep it synced up.