### PR TITLE
Fix release build workflow trigger

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -4,12 +4,24 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: Release version
+        description: Version
         required: true
-      releaseTag:
-        description: Release tag (leave empty)
+        default: "<major>.<minor>.<build>"
+
+      releaseType:
+        description: Type
+        default: "candidate"
+        required: true
+        type: choice
+        options:
+        - "candidate"
+        - "release"
+
+      releaseCandidate:
+        description: Candidate Number (Optional)
         required: false
-        default: ''
+        default: 0
+        type: number
 
 jobs:
   build:
@@ -44,4 +56,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run script
         run: |
-          python release.py --config $GITHUB_WORKSPACE/config.yml ${{ github.event.inputs.releaseVersion }} ${{ github.event.inputs.releaseTag }}
+          python release.py --config $GITHUB_WORKSPACE/config.yml --version ${{ github.event.inputs.releaseVersion }} --type ${{ github.event.inputs.releaseType }} --candidate ${{ github.event.inputs.releaseCandidate}}

--- a/git.py
+++ b/git.py
@@ -41,9 +41,18 @@ class GitRepository:
                                     "commit %h%nAuthor: %an <%ad>%n"
                                     "Commit: %cn <%cd>%n%n    %s\"".format(tags[1], tags[0]))
 
-    def get_latest_tag_commit(self, pattern):
-        tag = self._git_get_output("for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | grep '{}' | head -n1"
+    def get_latest_tag_name(self, pattern) -> str:
+        """
+        @brief Retrieves the name of the most recent version tag commit.
+        """
+        return self._git_get_output("for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | grep '{}' | head -n1"
                                    .format(pattern))
+
+    def get_latest_tag_commit(self, pattern):
+        """
+        @brief Retrieves the SHA of the most recent version tag commit.
+        """
+        tag = self.get_latest_tag_name(self, pattern)
 
         if len(tag) < 1:
             return ""
@@ -51,6 +60,9 @@ class GitRepository:
         return self._git_get_output("rev-parse --short {}^".format(tag))
 
     def update_repository(self):
+        """
+        @brief Updates the local repo to the most recent commit and deletes any untracked changes
+        """
         self._git_redirected_success("checkout '{}'".format(self.branch))
         self._git_redirected_success("fetch --tags origin".format(self.branch))
         self._git_redirected_success("reset --hard 'origin/{}'".format(self.branch))
@@ -72,6 +84,10 @@ class GitRepository:
         return stashed_changes
 
     def commit_and_tag(self, tag_name):
+        """
+        @brief  Commit, tag (annotated), and push to origin/repo
+        """
+        
         self._git_redirected_success("add .")
         self._git_redirected_success(
             "commit -m 'Automated build commit' --author='SirKnightly <SirKnightlySCP@gmail.com>'")

--- a/release.py
+++ b/release.py
@@ -48,21 +48,6 @@ def main():
     parser.add_argument("--type",       help="Either \'candidate\' or \'release\'")
     parser.add_argument("--candidate",  help="If --type = \'candidate\', this specifies the candidate number.  Is ignored if --type = \'release\'")
 
-    # args is a dict with argument names as dict keys and the argument values as dict values 
-    args = parser.parse_args()
-
-    # Read in configuration data from config.yml
-    # See config.yml.sample to see dict structure
-    config = {}
-    with open(args.config, "r") as f:
-        try:
-            config = yaml.safe_load(f)
-            # Support some variables in the config
-            expand_config_vars(config)
-        except yaml.YAMLError as e:
-            print(e)
-            sys.exit(1)
-
     # Verify version string is valid
     if not semantic_version.validate(args.version):
         print("Error: Specified version is not a valid version string!")


### PR DESCRIPTION
Simplifies the release_build workflow  by moving most of the functionality into `release.py` instead of using a state machine class that allows for resumption of a failed job.

Fixes a test of the tag name.  Previously the SHA of the most recent tag in the repo was being tested against the SHA of the current HEAD commit.  Since tags are floating in the repo, they never show up in the master branch's commit history and thus the test would always pass.  However, `git push` may later fail because a tag name already existed.

Resumption shouldn't be a concern with a script like this because the only action to be concerned about is at the end where it commits, tags, and pushes to the repo.