### PR TITLE
Remove extra argument to function call

### DIFF
--- a/git.py
+++ b/git.py
@@ -52,7 +52,7 @@ class GitRepository:
         """
         @brief Retrieves the SHA of the most recent version tag commit.
         """
-        tag = self.get_latest_tag_name(self, pattern)
+        tag = self.get_latest_tag_name(pattern)
 
         if len(tag) < 1:
             return ""


### PR DESCRIPTION
`self` is implicitly passed to all instance methods in Python, so it's not needed here and will be interpreted as an extra argument, causing a TypeError.