### PR TITLE
Fix typo. Extend debug message a bit

### DIFF
--- a/build_monitor/monitors.py
+++ b/build_monitor/monitors.py
@@ -167,7 +167,7 @@ class GitHubMonitor(Monitor):
                 break
         
         if current_run == None:
-            raise Exception("No runs found for {}").format(self.tag_name)
+            raise Exception("{} has not been run yet for tag {}".format(filename, self.tag_name))
 
         # Set the status and result members accordign to the most recent run result
         self.status = current_run.status


### PR DESCRIPTION
This one isn't as critical due to the nature of monitor object, the workflow will still work with the typo erroring out, but it won't generate a useful error message.

This change also makes the message a smidge more useful by also including the filename of the workflow that did not run the given tag_name yet.