### PR TITLE
Replace FTP file listing with HTTP file listing

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -38,10 +38,6 @@ templates:
     installer: templates/installer.mako
 
 ftp:
-    host: example.com
-    user: asdf
-    pass: xyz
-    path: public_html/builds/{type}/{version}/
     mirrors:
       - http://scp.indiegames.us/builds/{type}/{version}/{file}
       - https://porphyrion.feralhosting.com/datacorder/builds/{type}/{version}/{file}

--- a/file_list.py
+++ b/file_list.py
@@ -56,7 +56,7 @@ def get_release_files(tag_name, config) -> Tuple[List[ReleaseFile], Dict[str, So
     return binary_files, source_files
 
 
-def get_ftp_files(build_type, tag_name, config):
+def get_nightly_files(tag_name, config):
     tag_regex = re.compile("nightly_(.*)")
     build_group_regex = re.compile("nightly_.*-builds-([^.]+).*")
     link_regex = re.compile(r'<a href="(nightly_[^"]+)"')
@@ -65,7 +65,7 @@ def get_ftp_files(build_type, tag_name, config):
 
     files = []
     for mirror in config["ftp"]["mirrors"]:
-        url = mirror.format(type=build_type, version=version_str, file="")
+        url = mirror.format(type="nightly", version=version_str, file="")
 
         try:
             response = requests.get(url)
@@ -101,7 +101,7 @@ def get_ftp_files(build_type, tag_name, config):
             group_match = group_match.replace("Mac", "MacOSX")
 
         for mirror in config["ftp"]["mirrors"]:
-            download_url = mirror.format(type=build_type, version=version_str, file=file)
+            download_url = mirror.format(type="nightly", version=version_str, file=file)
             if primary_url is None:
                 primary_url = download_url
             else:

--- a/file_list.py
+++ b/file_list.py
@@ -1,5 +1,4 @@
 import re
-from ftplib import FTP, error_perm
 from typing import List, Tuple, Dict
 
 import requests
@@ -60,21 +59,26 @@ def get_release_files(tag_name, config) -> Tuple[List[ReleaseFile], Dict[str, So
 def get_ftp_files(build_type, tag_name, config):
     tag_regex = re.compile("nightly_(.*)")
     build_group_regex = re.compile("nightly_.*-builds-([^.]+).*")
+    link_regex = re.compile(r'<a href="(nightly_[^"]+)"')
+
+    version_str = tag_regex.match(tag_name).group(1)
 
     files = []
-    try:
-        with FTP(config["ftp"]["host"], config["ftp"]["user"], config["ftp"]["pass"]) as ftp:
-            version_str = tag_regex.match(tag_name).group(1)
+    for mirror in config["ftp"]["mirrors"]:
+        url = mirror.format(type=build_type, version=version_str, file="")
 
-            path_template = config["ftp"]["path"]
-            path = path_template.format(type=build_type, version=version_str)
-            file_entries = list(ftp.mlsd(path, ["type"]))
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+        except Exception as ex:
+            print("Failed to retrieve filelist from %s: %s" % (url, ex))
+            continue
 
-            for entry in file_entries:
-                if entry[1]["type"] == "file":
-                    files.append(entry[0])
-    except error_perm:
-        print("Received permanent FTP error!")
+        files = link_regex.findall(response.text)
+        break
+
+    if not files:
+        print("No files found!")
         return []
 
     out_data = []
@@ -91,7 +95,7 @@ def get_ftp_files(build_type, tag_name, config):
         # x64 is the name Visual Studio uses but Win64 works better for us since that gets displayed in the nightly post
         if "x64" in group_match:
             group_match = group_match.replace("x64", "Win64")
-        
+
         # nebula.py expects "MacOSX" as the group, but the build actions may pass off as just "Mac"
         if "Mac" == group_match:
             group_match = group_match.replace("Mac", "MacOSX")

--- a/nightly.py
+++ b/nightly.py
@@ -65,7 +65,7 @@ class NightlyState(ScriptState):
 
     def post_build_actions(self):
         # Get the file list
-        files = file_list.get_ftp_files("nightly", self.tag_name, config)
+        files = file_list.get_nightly_files(self.tag_name, config)
 
         print("Generating installer manifests")
         for file in files:

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -1,23 +1,34 @@
 import unittest
-from unittest import mock
-from unittest.mock import Mock
+import requests_mock
+
+FILE_LISTING = '''<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /builds/nightly/test_tag</title>
+ </head>
+ <body>
+<h1>Index of /builds/nightly/test_tag</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/builds/nightly/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="nightly_test_tag-builds-Linux.tar.gz">nightly_test_tag-builds-Linux.tar.gz</a></td><td align="right">2023-04-13 06:25  </td><td align="right"> 30M</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="nightly_test_tag-builds-MacOSX.tar.gz">nightly_test_tag-builds-MacOSX.tar.gz</a></td><td align="right">2023-04-13 06:24  </td><td align="right"> 17M</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="nightly_test_tag-builds-Win32.zip">nightly_test_tag-builds-Win32.zip</a></td><td align="right">2023-04-13 06:43  </td><td align="right"> 29M</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="nightly_test_tag-builds-x64.zip">nightly_test_tag-builds-x64.zip</a></td><td align="right">2023-04-13 06:44  </td><td align="right"> 35M</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="nightly_test_tag-debug-Win32.7z">nightly_test_tag-debug-Win32.7z</a></td><td align="right">2023-04-13 06:43  </td><td align="right"> 68M</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="nightly_test_tag-debug-x64.7z">nightly_test_tag-debug-x64.7z</a></td><td align="right">2023-04-13 06:44  </td><td align="right"> 71M</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+<address>Apache/2.4.25 (Debian) Server at datacorder.porphyrion.feralhosting.com Port 80</address>
+</body></html>
+'''
 
 class FtpTestCase(unittest.TestCase):
-    @mock.patch("ftplib.FTP", autospec=True)
-    def test_file_listing(self, MockFTP):
-        MockFTP.return_value = Mock()
-        mock_ftp_obj = MockFTP()
-        mock_ftp_obj.__enter__ = Mock(return_value=mock_ftp_obj)
-        mock_ftp_obj.__exit__ = Mock()
+    @requests_mock.mock()
+    def test_file_listing(self, m):
+        m.get("http://01.example.org/builds/nightly/test_tag/", text=FILE_LISTING)
 
-        mock_ftp_obj.mlsd = Mock(return_value=[
-            (".", {"type": "cdir"}),
-            ("..", {"type": "pdir"}),
-            ("nightly_test_tag-builds-Linux.tar.gz", {"type": "file"}),
-            ("nightly_test_tag-builds-MacOSX.tar.gz", {"type": "file"}),
-            ("nightly_test_tag-builds-Win32.zip", {"type": "file"}),
-            ("nightly_test_tag-builds-x64.zip", {"type": "file"}),
-        ])
         test_config = {
             "ftp": {
                 "host": "example.org",

--- a/test/test_nightly_list.py
+++ b/test/test_nightly_list.py
@@ -24,17 +24,13 @@ FILE_LISTING = '''<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 </body></html>
 '''
 
-class FtpTestCase(unittest.TestCase):
+class NightlyListTestCase(unittest.TestCase):
     @requests_mock.mock()
     def test_file_listing(self, m):
         m.get("http://01.example.org/builds/nightly/test_tag/", text=FILE_LISTING)
 
         test_config = {
             "ftp": {
-                "host": "example.org",
-                "user": "user",
-                "pass": "pass",
-                "path": "public_html/builds/{type}/{version}/",
                 "mirrors": [
                     "http://01.example.org/builds/{type}/{version}/{file}",
                     "http://02.example.org/builds/{type}/{version}/{file}",
@@ -43,7 +39,7 @@ class FtpTestCase(unittest.TestCase):
         }
 
         import file_list
-        files = file_list.get_ftp_files("nightly", "nightly_test_tag", test_config)
+        files = file_list.get_nightly_files("nightly_test_tag", test_config)
         self.assertEqual(4, len(files))
 
 


### PR DESCRIPTION
We currently don't have FTP access to scp.indiegames.us, I don't want to deal with the encrypted config file to switch to the other mirror and FTP is insecure anyway since the password isn't encrypted.
So overall, I'll count this as a win; less settings, fewer requirements for mirrors and more secure.