### PR TITLE
Add Point Releases To Release Script

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -16,6 +16,8 @@ on:
         options:
         - "candidate"
         - "release"
+        - "point_release"
+        - "point_release_candidate"
 
       releaseCandidate:
         description: Candidate Number (Optional)


### PR DESCRIPTION
This should allow us to initiate a point release or point release candidate.  

As a note, a branch with the format `pr_<major>_<minor>_<build>` must exist for those releases to succeed, but I am flexible to change the formatting. Regular releases happen as normal.  In draft status because we don't want to merge it before stable and mess up stable's release in case I made a mistake.  I'm still waiting for the test cases to finish on my branch.