### PR TITLE
Open version_override.cmake in write mode instead of append mode.

### DIFF
--- a/nightly.py
+++ b/nightly.py
@@ -90,7 +90,7 @@ class NightlyState(ScriptState):
         return "nightly_*"
 
     def do_replacements(self, date, current_commit):
-        with open(os.path.join(self.config["git"]["repo"], "version_override.cmake"), "a") as test:
+        with open(os.path.join(self.config["git"]["repo"], "version_override.cmake"), "w") as test:
             test.write("set(FSO_VERSION_REVISION {})\n".format(date))
             test.write("set(FSO_VERSION_REVISION_STR {}_{})\n".format(date, current_commit))
 

--- a/release.py
+++ b/release.py
@@ -88,7 +88,7 @@ def main():
     print("  tag: {}".format(tag_name))
 
     # Configure version_override.cmake for proper in-game version ident
-    with open(os.path.join(config["git"]["repo"], "version_override.cmake"), "a") as f:
+    with open(os.path.join(config["git"]["repo"], "version_override.cmake"), "w") as f:
         f.write("set(FSO_VERSION_MAJOR {})\n".format(version.major))
         f.write("set(FSO_VERSION_MINOR {})\n".format(version.minor))
         f.write("set(FSO_VERSION_BUILD {})\n".format(version.patch))


### PR DESCRIPTION
If there's an existing version_override.cmake (which there is expected to be for a point-release, since it'll be based on the previous stable release), appending will cause there to be two sets of version information settings when we only want one. This shouldn't affect nightlies, but there's no reason for them to append either.