### PR TITLE
Add EXTRA_FLAGS support and README for standalone updater

### DIFF
--- a/standalone_update/.env.default
+++ b/standalone_update/.env.default
@@ -17,3 +17,6 @@ BUILD_EXPORTS_DIR=/usr/share/games/fs2source/build_exports
 
 # Git reference
 REFERENCE=origin/master
+
+# Additional command line flags passed to the game binary (e.g. -prefer_ipv4)
+#EXTRA_FLAGS=""

--- a/standalone_update/README.md
+++ b/standalone_update/README.md
@@ -1,0 +1,113 @@
+# Standalone Server Update Script
+
+Automated build-and-deploy script for FSO standalone game servers. Designed to run on headless Linux VPS servers, typically triggered by cron.
+
+## What It Does
+
+1. Fetches the latest source from a local FSO git repo at a configurable ref (branch, tag, etc.)
+2. Creates a git worktree export and builds the engine via cmake/make
+3. Optionally updates a mod directory (git or svn)
+4. Stops any running server instance (screen session)
+5. Deploys the new build and restarts the server in a detached screen
+6. Cleans up old build exports, keeping only the most recent
+
+## Prerequisites
+
+- Linux system with bash
+- git, cmake, make
+- gcc or clang (and associated C++ compiler)
+- screen
+- A local clone of the [fs2open](https://github.com/scp-fs2open/fs2open.github.com) repository with submodules
+- A game root directory with the base game data files (e.g. retail VPs)
+- Optional: gdb or lldb for debugger-attached runs
+
+## Installation
+
+1. Clone or copy this directory onto your server.
+
+2. Ensure the FSO source repo is cloned locally with submodules:
+   ```bash
+   git clone --recurse-submodules https://github.com/scp-fs2open/fs2open.github.com.git /usr/share/games/fs2source/fs2_open
+   ```
+
+3. Create your game root directory with the base game data:
+   ```bash
+   mkdir -p /usr/share/games/freespace2
+   # Copy retail VP files, etc. into this directory
+   ```
+
+4. Optionally create a `.env` file with your overrides (see Configuration below).
+
+5. Make sure the `update` script is executable:
+   ```bash
+   chmod +x update
+   ```
+
+## Configuration
+
+The script uses a two-layer config system:
+
+- `.env.default` — Checked-in defaults. Don't edit this on your server.
+- `.env` — Your local overrides (gitignored). Only set values that differ from defaults.
+
+### Available Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `BUILD_TYPE` | `Release` | CMake build type (`Release`, `Debug`, `FastDebug`, etc.) |
+| `COMPILER` | `gcc` | Compiler toolchain (`gcc` or `clang`) |
+| `USE_DEBUGGER` | _(unset)_ | Set to any non-empty value to run the server under gdb/lldb |
+| `FSO_REPO` | `/usr/share/games/fs2source/fs2_open` | Path to the local FSO git repository |
+| `GAME_ROOT` | `/usr/share/games/freespace2` | Path to the game data directory where builds are deployed |
+| `BUILD_EXPORTS_DIR` | `/usr/share/games/fs2source/build_exports` | Working directory for build worktrees |
+| `MOD_DIRNAME` | _(unset)_ | Mod folder name (e.g. `fotg`). Enables mod-specific launch flags. |
+| `MOD_VCS` | _(unset)_ | VCS for auto-updating the mod folder (`git` or `svn`). Leave unset to manage manually. |
+| `REFERENCE` | `origin/master` | Git reference to build from — branch (`origin/master`), tag (`release_25_0_0`), or commit hash |
+| `EXTRA_FLAGS` | _(unset)_ | Additional command line flags passed to the game binary (e.g. `-prefer_ipv4`) |
+
+### Example `.env`
+
+```bash
+BUILD_TYPE=FastDebug
+GAME_ROOT=/usr/share/games/fotg
+MOD_DIRNAME=fotg
+MOD_VCS=git
+REFERENCE=release_25_0_0
+EXTRA_FLAGS=-prefer_ipv4
+```
+
+All variables can also be passed as command line arguments (run `./update -h` for usage).
+
+## Cron Setup
+
+The script is intended to be run via cron. Example crontab entry that runs daily at 09:00 UTC:
+
+```cron
+# Set timezone to UTC for this crontab
+CRON_TZ=UTC
+
+# Run script daily at 0900 UTC
+0 9 * * * /usr/share/games/fs2source/nightlybuild/standalone_update/update > /home/scpuser/standalone_update.log 2>&1
+```
+
+The script will exit early with an error if the current day's build already exists (i.e. no new export is needed when the ref hasn't changed), so running it frequently is safe.
+
+## Directory Structure
+
+After setup, the typical directory layout on a server looks like:
+
+```
+/usr/share/games/
+├── fs2source/
+│   ├── fs2_open/                  # FSO source repo (git clone)
+│   ├── build_exports/             # Worktree build artifacts (managed by script)
+│   └── nightlybuild/
+│       └── standalone_update/     # This directory
+│           ├── update             # The script
+│           ├── .env.default       # Default configuration
+│           └── .env               # Your overrides (gitignored)
+└── freespace2/                    # Game root (retail data + deployed binary)
+    ├── fs2_open_20250226          # Currently deployed build
+    ├── root_fs2.vp
+    └── ...
+```

--- a/standalone_update/update
+++ b/standalone_update/update
@@ -18,7 +18,7 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
 fi
 
 # Parse command line arguments (overrides config file)
-while getopts "t:d:c:r:m:v:h" opt; do
+while getopts "t:d:c:r:m:v:f:h" opt; do
     case "${opt}" in
         t) BUILD_TYPE="${OPTARG}" ;;
         d) USE_DEBUGGER="${OPTARG}" ;;
@@ -26,8 +26,9 @@ while getopts "t:d:c:r:m:v:h" opt; do
         r) REFERENCE="${OPTARG}" ;;
         m) MOD_DIRNAME="${OPTARG}" ;;
         v) MOD_VCS="${OPTARG}" ;;
+        f) EXTRA_FLAGS="${OPTARG}" ;;
         h)
-            echo "Usage: $0 [-t BUILD_TYPE] [-d USE_DEBUGGER] [-c COMPILER] [-r REFERENCE] [-m MOD_DIRNAME] [-v MOD_VCS]"
+            echo "Usage: $0 [-t BUILD_TYPE] [-d USE_DEBUGGER] [-c COMPILER] [-r REFERENCE] [-m MOD_DIRNAME] [-v MOD_VCS] [-f EXTRA_FLAGS]"
             exit 0
             ;;
         *)
@@ -194,9 +195,9 @@ echo "Starting screen and ${MAIN_PROCESS}/${MOD_DIRNAME:-freespace2}"
 (
     cd ${GAME_ROOT}
     if [ -n "${USE_DEBUGGER}" ]; then
-        screen -dmS server ${DEBUGGER} ${DEBUGGER_FLAG} "r -standalone -noninteractive${MOD_DIRNAME:+ -mod ${MOD_DIRNAME}}" "fs2_open_${DATE}"
+        screen -dmS server ${DEBUGGER} ${DEBUGGER_FLAG} "r -standalone${EXTRA_FLAGS:+ ${EXTRA_FLAGS}} -noninteractive${MOD_DIRNAME:+ -mod ${MOD_DIRNAME}}" "fs2_open_${DATE}"
     else
-        screen -dmS server ./fs2_open_${DATE} -standalone -noninteractive${MOD_DIRNAME:+ -mod ${MOD_DIRNAME}}
+        screen -dmS server ./fs2_open_${DATE} -standalone${EXTRA_FLAGS:+ ${EXTRA_FLAGS}} -noninteractive${MOD_DIRNAME:+ -mod ${MOD_DIRNAME}}
     fi
 )
 


### PR DESCRIPTION
Add configurable EXTRA_FLAGS env var for passing additional command line flags to the game binary (e.g. -prefer_ipv4), avoiding the need to patch the script per-server. Also add a README documenting prerequisites, installation, configuration, and cron setup.