### PR TITLE
Add pull request reference support to update script

### DIFF
--- a/standalone_update/.env.default
+++ b/standalone_update/.env.default
@@ -11,6 +11,7 @@ GAME_ROOT=/usr/share/games/freespace2
 BUILD_EXPORTS_DIR=/usr/share/games/fs2source/build_exports
 
 # FSO Git reference
+# Branch (origin/master), tag (release_25_0_0), commit hash, or pull request (pr/NUMBER or pull/NUMBER to fetch from GitHub)
 REFERENCE=origin/master
 
 # Additional command line flags passed to the game binary (e.g. -prefer_ipv4)

--- a/standalone_update/README.md
+++ b/standalone_update/README.md
@@ -62,7 +62,7 @@ The script uses a two-layer config system:
 | `BUILD_EXPORTS_DIR` | `/usr/share/games/fs2source/build_exports` | Working directory for build worktrees |
 | `MOD_DIRNAME` | _(unset)_ | Comma-delimited mod list (e.g. `fotg` or `fotg,fotg-test`). First mod is primary and determines the engine data folder. Passed directly to the engine's `-mod` flag. |
 | `MOD_VCS` | _(unset)_ | VCS per mod, positionally matched to `MOD_DIRNAME` (`git`, `svn`, or empty for unmanaged). E.g. `git,svn` or `git,` |
-| `REFERENCE` | `origin/master` | Git reference to build from — branch (`origin/master`), tag (`release_25_0_0`), or commit hash |
+| `REFERENCE` | `origin/master` | Git reference to build from — branch (`origin/master`), tag (`release_25_0_0`), commit hash, or pull request (`pr/NUMBER` or `pull/NUMBER`) |
 | `EXTRA_FLAGS` | _(unset)_ | Additional command line flags passed to the game binary (e.g. `-prefer_ipv4`) |
 
 ### Example `.env`
@@ -74,6 +74,12 @@ MOD_DIRNAME=fotg,fotg-test
 MOD_VCS=git,svn
 REFERENCE=release_25_0_0
 EXTRA_FLAGS=-prefer_ipv4
+```
+
+To build from a GitHub pull request instead:
+
+```bash
+REFERENCE=pr/7306
 ```
 
 All variables can also be passed as command line arguments (run `./update -h` for usage).

--- a/standalone_update/update
+++ b/standalone_update/update
@@ -188,6 +188,18 @@ else
     echo "Fetching updates for parent repo and submodules..."
     git -C "$FSO_REPO" fetch --tags --force --recurse-submodules || error_exit "Failed to fetch updates from remote repositories"
 
+    # If REFERENCE is a PR (pr/NUMBER or pull/NUMBER), fetch the PR head ref
+    # Falls back to treating as a normal ref if the PR fetch fails (e.g. a branch named pr/123)
+    if [[ "$REFERENCE" =~ ^(pr|pull)/([0-9]+)$ ]]; then
+        PR_NUMBER="${BASH_REMATCH[2]}"
+        echo "Fetching pull request #${PR_NUMBER}..."
+        if git -C "$FSO_REPO" fetch origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}" 2>/dev/null; then
+            REFERENCE="origin/pr/${PR_NUMBER}"
+        else
+            echo "WARNING: Could not fetch pull request #${PR_NUMBER}, treating '${REFERENCE}' as a regular ref"
+        fi
+    fi
+
     echo "Resolving reference '$REFERENCE' to commit hash..."
     HASH=$(git -C "$FSO_REPO" rev-parse --short "$REFERENCE" 2>/dev/null) || error_exit "Reference '$REFERENCE' not found in repository"
 


### PR DESCRIPTION
Allow REFERENCE to use pr/NUMBER or pull/NUMBER syntax to fetch and build from GitHub pull requests. Falls back to treating the value as a regular ref if the PR fetch fails.