### PR TITLE
Add Update & Restart action and build metadata tracking

### DIFF
--- a/standalone_update/build_info.example.json
+++ b/standalone_update/build_info.example.json
@@ -1,0 +1,12 @@
+{
+  "binary": "fs2_open_20260323120000_a1b2c3d",
+  "build_type": "Release",
+  "compiler": "gcc",
+  "reference": "origin/master",
+  "commit": "a1b2c3d",
+  "extra_flags": "",
+  "mod_dirname": "fotg",
+  "mod_vcs": "git",
+  "built_at": "2026-03-23T12:00:00Z",
+  "mods_updated_at": "2026-03-23T14:30:00Z"
+}

--- a/standalone_update/update
+++ b/standalone_update/update
@@ -20,8 +20,9 @@ fi
 # Parse command line arguments (overrides config file)
 RESTART_ONLY=""
 STOP_ONLY=""
+UPDATE_MODS_ONLY=""
 
-while getopts "t:d:c:r:m:v:f:RSh" opt; do
+while getopts "t:d:c:r:m:v:f:RSUh" opt; do
     case "${opt}" in
         t) BUILD_TYPE="${OPTARG}" ;;
         d) USE_DEBUGGER="${OPTARG}" ;;
@@ -32,10 +33,12 @@ while getopts "t:d:c:r:m:v:f:RSh" opt; do
         f) EXTRA_FLAGS="${OPTARG}" ;;
         R) RESTART_ONLY=yes ;;
         S) STOP_ONLY=yes ;;
+        U) UPDATE_MODS_ONLY=yes ;;
         h)
-            echo "Usage: $0 [-t BUILD_TYPE] [-d USE_DEBUGGER] [-c COMPILER] [-r REFERENCE] [-m MOD_DIRNAME] [-v MOD_VCS] [-f EXTRA_FLAGS] [-R] [-S]"
+            echo "Usage: $0 [-t BUILD_TYPE] [-d USE_DEBUGGER] [-c COMPILER] [-r REFERENCE] [-m MOD_DIRNAME] [-v MOD_VCS] [-f EXTRA_FLAGS] [-R] [-S] [-U]"
             echo "  -R  Restart the server using the existing build (skip fetch/build)"
             echo "  -S  Stop the server without restarting"
+            echo "  -U  Update mod data and restart the server (skip fetch/build)"
             exit 0
             ;;
         *)
@@ -46,8 +49,12 @@ while getopts "t:d:c:r:m:v:f:RSh" opt; do
 done
 shift $((OPTIND - 1))
 
-if [ -n "${RESTART_ONLY}" ] && [ -n "${STOP_ONLY}" ]; then
-    error_exit "-R (restart) and -S (stop) are mutually exclusive"
+_exclusive_count=0
+[ -n "${RESTART_ONLY}" ] && _exclusive_count=$((_exclusive_count + 1))
+[ -n "${STOP_ONLY}" ] && _exclusive_count=$((_exclusive_count + 1))
+[ -n "${UPDATE_MODS_ONLY}" ] && _exclusive_count=$((_exclusive_count + 1))
+if [ $_exclusive_count -gt 1 ]; then
+    error_exit "-R (restart), -S (stop), and -U (update mods) are mutually exclusive"
 fi
 
 # Auto-derive MOD_ROOTS array from comma-delimited MOD_DIRNAME
@@ -137,6 +144,56 @@ start_server() {
     )
 }
 
+write_build_info() {
+    local _build_info="${GAME_ROOT}/build_info.json"
+    echo "Writing build metadata to ${_build_info}..."
+    cat > "${_build_info}" <<BUILDINFO
+{
+  "binary": "${BINARY_NAME}",
+  "build_type": "${BUILD_TYPE}",
+  "compiler": "${COMPILER}",
+  "reference": "${REFERENCE}",
+  "commit": "${HASH}",
+  "extra_flags": "${EXTRA_FLAGS}",
+  "mod_dirname": "${MOD_DIRNAME}",
+  "mod_vcs": "${MOD_VCS}",
+  "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "mods_updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+BUILDINFO
+}
+
+update_build_info_mods() {
+    local _build_info="${GAME_ROOT}/build_info.json"
+    if [ ! -f "${_build_info}" ]; then
+        echo "No build_info.json found, skipping metadata update"
+        return
+    fi
+    echo "Updating mods_updated_at in ${_build_info}..."
+    local _now
+    _now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    # Use a temp file for portable in-place edit
+    sed "s/\"mods_updated_at\": \"[^\"]*\"/\"mods_updated_at\": \"${_now}\"/" \
+        "${_build_info}" > "${_build_info}.tmp" \
+        && mv "${_build_info}.tmp" "${_build_info}"
+}
+
+update_mods() {
+    for _i in "${!MOD_ROOTS[@]}"; do
+        _root="${MOD_ROOTS[$_i]}"
+        _vcs="${MOD_VCSS[$_i]:-}"
+        if [ -n "${_vcs}" ]; then
+            if [ "${_vcs}" = "git" ]; then
+                echo "Updating mod git folder at ${_root}..."
+                git -C "${_root}" pull || error_exit "Failed to update mod git folder at ${_root}"
+            elif [ "${_vcs}" = "svn" ]; then
+                echo "Updating mod svn folder at ${_root}..."
+                (cd "${_root}" && svn up) || error_exit "Failed to update mod svn folder at ${_root}"
+            fi
+        fi
+    done
+}
+
 ### Validation ###
 
 if [ ! -d "${GAME_ROOT}" ]; then
@@ -160,6 +217,18 @@ done
 
 if [ -n "${STOP_ONLY}" ]; then
     stop_server
+
+elif [ -n "${UPDATE_MODS_ONLY}" ]; then
+    EXISTING_BINARY=$(ls -1dt ${GAME_ROOT}/fs2_open_* 2>/dev/null | head -1)
+    if [ -z "${EXISTING_BINARY}" ]; then
+        error_exit "No existing build found in ${GAME_ROOT} to restart"
+    fi
+    BINARY_NAME=$(basename "${EXISTING_BINARY}")
+    echo "Update & Restart mode: updating mods and reusing existing build ${BINARY_NAME}"
+    update_mods
+    update_build_info_mods
+    stop_server
+    start_server
 
 elif [ -n "${RESTART_ONLY}" ]; then
     EXISTING_BINARY=$(ls -1dt ${GAME_ROOT}/fs2_open_* 2>/dev/null | head -1)
@@ -233,19 +302,7 @@ else
     echo "Running make inside build export build folder..."
     make -C "${BUILD_PATH}" || error_exit "make failed to run in: ${BUILD_PATH}"
 
-    for _i in "${!MOD_ROOTS[@]}"; do
-        _root="${MOD_ROOTS[$_i]}"
-        _vcs="${MOD_VCSS[$_i]:-}"
-        if [ -n "${_vcs}" ]; then
-            if [ "${_vcs}" = "git" ]; then
-                echo "Updating mod git folder at ${_root}..."
-                git -C "${_root}" pull || error_exit "Failed to update mod git folder at ${_root}"
-            elif [ "${_vcs}" = "svn" ]; then
-                echo "Updating mod svn folder at ${_root}..."
-                (cd "${_root}" && svn up) || error_exit "Failed to update mod svn folder at ${_root}"
-            fi
-        fi
-    done
+    update_mods
 
     BINARY_NAME="fs2_open_${BUILD_ID}"
 
@@ -261,6 +318,8 @@ else
 
     echo "Copying build to game folder..."
     cp -a ${BUILD_PATH}/bin/fs2_open_* "${GAME_ROOT}/${BINARY_NAME}" || error_exit "Failed to copy build to game root ${GAME_ROOT}"
+
+    write_build_info
 
     start_server
 

--- a/standalone_update/web/server.py
+++ b/standalone_update/web/server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 import os
 import subprocess
 import sys
@@ -63,8 +64,8 @@ LOG_LINES = int(os.environ.get('LOG_LINES', '100'))
 
 # Process tracking
 _running_process = None
-_running_action = None       # 'rebuilding', 'restarting', or 'stopping'
-_running_action_base = None  # 'rebuild', 'restart', or 'stop'
+_running_action = None       # 'rebuilding', 'updating', 'restarting', or 'stopping'
+_running_action_base = None  # 'rebuild', 'update', 'restart', or 'stop'
 _log_file = None
 
 
@@ -92,10 +93,13 @@ def get_status():
         # Immediately notify clients of completion
         _last_emitted_status = 'idle'
         socketio.emit('build_status', {'status': 'idle', 'is_running': False}, to='page:server')
+        # Push updated build info (may have changed after rebuild or mod update)
+        build_info = read_build_info()
+        socketio.emit('build_info', {'info': build_info}, to='page:server')
     return ('idle', False)
 
 
-def start_update(restart_only=False, stop_only=False):
+def start_update(restart_only=False, stop_only=False, update_mods_only=False):
     """Start the update script in the background. Returns True on success."""
     global _running_process, _running_action, _running_action_base, _log_file
     if not LOG_PATH:
@@ -106,6 +110,8 @@ def start_update(restart_only=False, stop_only=False):
 
     if stop_only:
         action, flag, running_label = 'stop', '-S', 'stopping'
+    elif update_mods_only:
+        action, flag, running_label = 'update', '-U', 'updating'
     elif restart_only:
         action, flag, running_label = 'restart', '-R', 'restarting'
     else:
@@ -306,12 +312,14 @@ def handle_join_page(page):
 @socketio.on('server_action')
 def handle_server_action(data):
     action = data.get('action', '') if isinstance(data, dict) else data
-    if action not in ('rebuild', 'restart', 'stop'):
+    if action not in ('rebuild', 'update', 'restart', 'stop'):
         return {'ok': False, 'error': 'Invalid action.'}
     if not LOG_PATH:
         return {'ok': False, 'error': 'UPDATE_LOG_PATH is not configured.'}
     kwargs = {}
-    if action == 'restart':
+    if action == 'update':
+        kwargs['update_mods_only'] = True
+    elif action == 'restart':
         kwargs['restart_only'] = True
     elif action == 'stop':
         kwargs['stop_only'] = True
@@ -348,6 +356,32 @@ def _sync_watcher_to_offset(filepath, offset):
         return
     with _watch_lock:
         _watch_state[filepath] = {'offset': offset, 'inode': inode}
+
+
+def _get_game_root():
+    """Resolve GAME_ROOT from .env override or .env.default."""
+    overrides = parse_env(ENV_PATH)
+    if 'GAME_ROOT' in overrides:
+        return overrides['GAME_ROOT']
+    for var in parse_env_default(ENV_DEFAULT_PATH):
+        if var.name == 'GAME_ROOT' and var.default_value:
+            return var.default_value
+    return ''
+
+
+def read_build_info():
+    """Read build_info.json from GAME_ROOT. Returns dict or None."""
+    game_root = _get_game_root()
+    if not game_root:
+        return None
+    path = os.path.join(game_root, 'build_info.json')
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
 
 
 def read_log_lines():
@@ -436,8 +470,10 @@ def build_controls():
     lines, log_error, offset = read_log_lines()
     if LOG_PATH and offset:
         _sync_watcher_to_offset(LOG_PATH, offset)
+    build_info = read_build_info()
     return render_template('server.html', status=status, is_running=is_running,
-                           lines=lines, log_path=LOG_PATH, log_error=log_error)
+                           lines=lines, log_path=LOG_PATH, log_error=log_error,
+                           build_info=build_info)
 
 
 @app.route('/game-config', methods=['GET'])

--- a/standalone_update/web/static/server_ws.js
+++ b/standalone_update/web/static/server_ws.js
@@ -6,13 +6,14 @@
     var logEl = document.getElementById('update-log');
     var statusEl = document.getElementById('build-status');
     var msgEl = document.getElementById('action-message');
-    var buttons = ['btn-rebuild', 'btn-restart', 'btn-stop'].map(function(id) {
+    var buttons = ['btn-rebuild', 'btn-update', 'btn-restart', 'btn-stop'].map(function(id) {
         return document.getElementById(id);
     });
 
     var STATUS_LABELS = {
         idle: 'Idle',
         rebuilding: 'Rebuilding...',
+        updating: 'Updating & Restarting...',
         restarting: 'Restarting...',
         stopping: 'Stopping...'
     };
@@ -28,8 +29,9 @@
     }
 
     buttons[0].addEventListener('click', function() { doAction('rebuild'); });
-    buttons[1].addEventListener('click', function() { doAction('restart'); });
-    buttons[2].addEventListener('click', function() { doAction('stop'); });
+    buttons[1].addEventListener('click', function() { doAction('update'); });
+    buttons[2].addEventListener('click', function() { doAction('restart'); });
+    buttons[3].addEventListener('click', function() { doAction('stop'); });
 
     socket.on('update_log_lines', function(msg) {
         if (!logEl) {
@@ -55,6 +57,45 @@
         if (logEl) {
             logEl.textContent = '';
         }
+    });
+
+    var BUILD_INFO_FIELDS = [
+        {key: 'binary', label: 'Binary'},
+        {key: 'build_type', label: 'Build Type'},
+        {key: 'compiler', label: 'Compiler'},
+        {key: 'reference', label: 'Reference'},
+        {key: 'commit', label: 'Commit', code: true},
+        {key: 'mod_dirname', label: 'Mod', suffix_key: 'mod_vcs'},
+        {key: 'extra_flags', label: 'Extra Flags', code: true},
+        {key: 'built_at', label: 'Built'},
+        {key: 'mods_updated_at', label: 'Mods Updated'}
+    ];
+
+    socket.on('build_info', function(msg) {
+        var container = document.querySelector('.build-info');
+        var info = msg.info;
+        if (!info) {
+            if (container) container.remove();
+            return;
+        }
+        if (!container) {
+            container = document.createElement('div');
+            container.className = 'build-info';
+            var controls = document.querySelector('.server-controls');
+            if (controls) controls.parentNode.insertBefore(container, controls.nextSibling);
+        }
+        var html = '<h3>Current Deployment</h3><table class="info-table">';
+        BUILD_INFO_FIELDS.forEach(function(f) {
+            var val = info[f.key];
+            if (!val) return;
+            var display = f.code ? '<code>' + val + '</code>' : val;
+            if (f.suffix_key && info[f.suffix_key]) {
+                display += ' <span class="info-secondary">(' + info[f.suffix_key] + ')</span>';
+            }
+            html += '<tr><td class="info-label">' + f.label + '</td><td>' + display + '</td></tr>';
+        });
+        html += '</table>';
+        container.innerHTML = html;
     });
 
     socket.on('build_status', function(msg) {

--- a/standalone_update/web/static/style.css
+++ b/standalone_update/web/static/style.css
@@ -308,9 +308,47 @@ button[type="submit"]:hover {
 }
 
 .status-indicator.rebuilding .status-dot,
+.status-indicator.updating .status-dot,
 .status-indicator.restarting .status-dot,
 .status-indicator.stopping .status-dot {
     background: #f39c12;
+}
+
+.build-info {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.build-info h3 {
+    font-size: 0.9rem;
+    color: #555;
+    margin-bottom: 0.5rem;
+}
+
+.info-table {
+    width: 100%;
+    font-size: 0.85rem;
+    border-collapse: collapse;
+}
+
+.info-table td {
+    padding: 0.2rem 0.5rem;
+    vertical-align: top;
+}
+
+.info-label {
+    color: #777;
+    white-space: nowrap;
+    width: 1%;
+    font-weight: 600;
+}
+
+.info-secondary {
+    color: #999;
+    font-size: 0.8rem;
 }
 
 .button-row {
@@ -341,6 +379,14 @@ button[type="submit"]:hover {
 
 .btn-rebuild:hover:not(:disabled) {
     background: #34495e;
+}
+
+.btn-update {
+    background: #27ae60;
+}
+
+.btn-update:hover:not(:disabled) {
+    background: #2ecc71;
 }
 
 .btn-restart {

--- a/standalone_update/web/templates/server.html
+++ b/standalone_update/web/templates/server.html
@@ -9,6 +9,7 @@
             <span class="status-dot"></span>
             {% if status == 'idle' %}Idle
             {% elif status == 'rebuilding' %}Rebuilding...
+            {% elif status == 'updating' %}Updating &amp; Restarting...
             {% elif status == 'restarting' %}Restarting...
             {% elif status == 'stopping' %}Stopping...
             {% endif %}
@@ -19,6 +20,11 @@
             <button type="button" class="btn btn-rebuild" id="btn-rebuild"
                     {{ 'disabled' if is_running }}>Rebuild</button>
             <span class="btn-hint">Fetch, build, and deploy a new binary</span>
+        </div>
+        <div>
+            <button type="button" class="btn btn-update" id="btn-update"
+                    {{ 'disabled' if is_running }}>Update &amp; Restart</button>
+            <span class="btn-hint">Update mod data and restart the server</span>
         </div>
         <div>
             <button type="button" class="btn btn-restart" id="btn-restart"
@@ -33,6 +39,27 @@
     </div>
     <div id="action-message"></div>
 </div>
+
+{% if build_info %}
+<div class="build-info">
+    <h3>Current Deployment</h3>
+    <table class="info-table">
+        <tr><td class="info-label">Binary</td><td>{{ build_info.binary }}</td></tr>
+        <tr><td class="info-label">Build Type</td><td>{{ build_info.build_type }}</td></tr>
+        <tr><td class="info-label">Compiler</td><td>{{ build_info.compiler }}</td></tr>
+        <tr><td class="info-label">Reference</td><td>{{ build_info.reference }}</td></tr>
+        <tr><td class="info-label">Commit</td><td><code>{{ build_info.commit }}</code></td></tr>
+        {% if build_info.mod_dirname %}
+        <tr><td class="info-label">Mod</td><td>{{ build_info.mod_dirname }}{% if build_info.mod_vcs %} <span class="info-secondary">({{ build_info.mod_vcs }})</span>{% endif %}</td></tr>
+        {% endif %}
+        {% if build_info.extra_flags %}
+        <tr><td class="info-label">Extra Flags</td><td><code>{{ build_info.extra_flags }}</code></td></tr>
+        {% endif %}
+        <tr><td class="info-label">Built</td><td>{{ build_info.built_at }}</td></tr>
+        <tr><td class="info-label">Mods Updated</td><td>{{ build_info.mods_updated_at }}</td></tr>
+    </table>
+</div>
+{% endif %}
 
 <h2>Update Log</h2>
 {% if log_error %}


### PR DESCRIPTION
Add a new -U flag and "Update & Restart" button that pulls mod data and restarts without rebuilding the binary. Extract mod update logic into a reusable function shared by the full rebuild and -U paths.

Write build_info.json to GAME_ROOT on each full rebuild, capturing binary name, build type, compiler, reference, commit, flags, and mod config. The -U path updates the mods_updated_at timestamp. Display this metadata in a dedicated panel on the Build Controls page, with live WebSocket updates when builds or mod updates complete.