### PR TITLE
Fix CSP blocking inline onchange handlers on Build Config page

### DIFF
--- a/standalone_update/web/static/config.js
+++ b/standalone_update/web/static/config.js
@@ -9,3 +9,10 @@ function toggleOverride(checkbox, varName) {
         row.classList.remove('overridden');
     }
 }
+
+document.querySelectorAll('input[name^="override_"]').forEach(function(checkbox) {
+    var varName = checkbox.name.slice('override_'.length);
+    checkbox.addEventListener('change', function() {
+        toggleOverride(checkbox, varName);
+    });
+});

--- a/standalone_update/web/templates/config.html
+++ b/standalone_update/web/templates/config.html
@@ -15,8 +15,7 @@
             <div class="var-header">
                 <label class="override-label">
                     <input type="checkbox" name="override_{{ var.name }}"
-                           {% if var.is_overridden %}checked{% endif %}
-                           onchange="toggleOverride(this, '{{ var.name }}')">
+                           {% if var.is_overridden %}checked{% endif %}>
                     <strong>{{ var.name }}</strong>
                 </label>
                 {% if var.description %}


### PR DESCRIPTION
Replace inline onchange attributes with event listeners registered from the external config.js, so they are not blocked by script-src 'self' CSP.