### PR TITLE
Fix PR ref fetch failing due to global fetch.prune and transient errors

### DIFF
--- a/standalone_update/update
+++ b/standalone_update/update
@@ -256,16 +256,27 @@ else
 
     echo "Fetching updates for parent repo and submodules..."
     git -C "$FSO_REPO" fetch --tags --force --recurse-submodules || error_exit "Failed to fetch updates from remote repositories"
+    sleep 1
 
     # If REFERENCE is a PR (pr/NUMBER or pull/NUMBER), fetch the PR head ref
     # Falls back to treating as a normal ref if the PR fetch fails (e.g. a branch named pr/123)
     if [[ "$REFERENCE" =~ ^(pr|pull)/([0-9]+)$ ]]; then
         PR_NUMBER="${BASH_REMATCH[2]}"
         echo "Fetching pull request #${PR_NUMBER}..."
-        if git -C "$FSO_REPO" fetch origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}" 2>/dev/null; then
+        PR_FETCHED=""
+        for _attempt in 1 2 3; do
+            if git -C "$FSO_REPO" fetch --no-prune origin "+pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}" 2>&1; then
+                PR_FETCHED=yes
+                break
+            else
+                echo "Fetch attempt ${_attempt} failed, retrying in 2 seconds..."
+                sleep 2
+            fi
+        done
+        if [ -n "${PR_FETCHED}" ]; then
             REFERENCE="origin/pr/${PR_NUMBER}"
         else
-            echo "WARNING: Could not fetch pull request #${PR_NUMBER}, treating '${REFERENCE}' as a regular ref"
+            echo "WARNING: Could not fetch pull request #${PR_NUMBER} after 3 attempts, treating '${REFERENCE}' as a regular ref"
         fi
     fi
 


### PR DESCRIPTION
The PR-specific git fetch was silently failing because fetch.prune=true (set globally) would delete refs under refs/remotes/origin/pr/ since they don't match refs/heads/* on the remote. Adds --no-prune and a + refspec prefix to force-update the local ref. Also adds a retry loop (3 attempts) for transient SSH/network failures, a 1-second delay after the submodule fetch, and shows stderr output for easier debugging.