### PR TITLE
Add game engine status detection and stale log indicators to web UI

### DIFF
--- a/standalone_update/web/server.py
+++ b/standalone_update/web/server.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import threading
+import shutil
 from datetime import datetime, timedelta
 
 from flask import Flask, render_template, request, redirect, url_for, flash
@@ -177,6 +178,7 @@ def get_log_panels():
 _watch_state = {}       # realpath -> {'offset': int, 'inode': int}
 _watch_lock = threading.Lock()
 _last_emitted_status = None
+_last_engine_running = None  # Track engine running state for change detection
 _watcher_started = False
 
 # Registry of files to watch: realpath -> {line_event, truncate_event, room}
@@ -246,11 +248,23 @@ def _check_and_emit_status():
         socketio.emit('build_status', {'status': status, 'is_running': is_running}, to='page:server')
 
 
+def _check_and_emit_engine_status():
+    """Poll for game engine process and emit changes to all connected pages."""
+    global _last_engine_running
+    running = is_engine_running()
+    if running != _last_engine_running:
+        _last_engine_running = running
+        payload = {'running': running}
+        socketio.emit('engine_status', payload, to='page:server')
+        socketio.emit('engine_status', payload, to='page:logs')
+
+
 def _file_watcher():
     """Background greenlet that polls log files and build status for changes."""
     while True:
         socketio.sleep(0.25)
         _check_and_emit_status()
+        _check_and_emit_engine_status()
         for filepath, reg in _watch_registry.items():
             _check_and_emit_file(filepath, reg['line_event'], reg['truncate_event'], reg['room'])
 
@@ -300,6 +314,17 @@ def handle_join_page(page):
     join_room(room)
     _room_occupancy[room] = _room_occupancy.get(room, 0) + 1
     _client_rooms[request.sid] = room
+
+    # Send current engine status so the client is never stale
+    running = is_engine_running()
+    socketio.emit('engine_status', {'running': running}, to=request.sid)
+
+    if page == 'logs':
+        # One-time lsof check: tell the client which log files the engine has open
+        panels_active = {}
+        for panel in get_log_panels():
+            panels_active[panel['id']] = is_log_open_by_engine(panel['path'])
+        socketio.emit('log_file_active', {'panels': panels_active}, to=request.sid)
 
     if page == 'server':
         # Send current build status so the client is never stale
@@ -381,6 +406,56 @@ def read_build_info():
         with open(path) as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _get_engine_process_name():
+    """Determine the process name to look for (fs2_open, or debugger if USE_DEBUGGER is set)."""
+    overrides = parse_env(ENV_PATH)
+    use_debugger = overrides.get('USE_DEBUGGER', '')
+    if not use_debugger:
+        # Check .env.default — USE_DEBUGGER is commented out by default,
+        # so parse_env_default won't return a value unless it's uncommented
+        for var in parse_env_default(ENV_DEFAULT_PATH):
+            if var.name == 'USE_DEBUGGER' and var.default_value:
+                use_debugger = var.default_value
+                break
+    if use_debugger:
+        return 'lldb' if sys.platform == 'darwin' else 'gdb'
+    return 'fs2_open'
+
+
+def is_engine_running():
+    """Check whether the game engine process is currently running."""
+    process_name = _get_engine_process_name()
+    pgrep = shutil.which('pgrep')
+    if not pgrep:
+        return None  # Can't determine
+    try:
+        result = subprocess.run(
+            [pgrep, process_name],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return result.returncode == 0
+    except OSError:
+        return None
+
+
+def is_log_open_by_engine(filepath):
+    """Check whether the engine process currently has a specific log file open."""
+    if not filepath or not os.path.exists(filepath):
+        return False
+    process_name = _get_engine_process_name()
+    lsof = shutil.which('lsof')
+    if not lsof:
+        return None  # Can't determine
+    try:
+        result = subprocess.run(
+            [lsof, '-c', process_name, '--', filepath],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return result.returncode == 0
+    except OSError:
         return None
 
 

--- a/standalone_update/web/static/logs_ws.js
+++ b/standalone_update/web/static/logs_ws.js
@@ -12,11 +12,48 @@
 
     socket.on('connect', function() {
         socket.emit('join_page', 'logs');
-        if (statusEl) statusEl.textContent = 'Live (connected)';
+        if (statusEl) statusEl.textContent = 'Connected';
     });
 
     socket.on('disconnect', function() {
         if (statusEl) statusEl.textContent = 'Disconnected \u2014 reconnecting...';
+    });
+
+    // Engine process status — combine ongoing engine_status with one-time
+    // lsof check (log_file_active) to determine per-panel badge state.
+    var engineRunning = null;    // updated by engine_status events
+    var logFileActive = {};      // panel_id -> bool, set once by log_file_active
+
+    function updateEngineBadges() {
+        var badges = document.querySelectorAll('[id^="engine-status-"]');
+        badges.forEach(function(el) {
+            var panelId = el.id.replace(/^engine-status-/, '');
+            var cls, label;
+            if (engineRunning === null) {
+                cls = 'unknown'; label = 'Engine status unknown';
+            } else if (!engineRunning) {
+                cls = 'stopped'; label = 'Engine not running';
+            } else if (logFileActive[panelId] === true) {
+                cls = 'running'; label = 'Log active';
+            } else if (logFileActive[panelId] === false) {
+                cls = 'stale'; label = 'Engine running \u2014 log stale';
+            } else {
+                cls = 'running'; label = 'Engine running';
+            }
+            el.className = 'engine-status ' + cls;
+            var labelEl = el.querySelector('.engine-label');
+            if (labelEl) labelEl.textContent = label;
+        });
+    }
+
+    socket.on('engine_status', function(msg) {
+        engineRunning = msg.running;
+        updateEngineBadges();
+    });
+
+    socket.on('log_file_active', function(msg) {
+        logFileActive = msg.panels || {};
+        updateEngineBadges();
     });
 
     Object.keys(panels).forEach(function(id) {

--- a/standalone_update/web/static/server_ws.js
+++ b/standalone_update/web/static/server_ws.js
@@ -98,6 +98,22 @@
         container.innerHTML = html;
     });
 
+    // Engine process status
+    var ENGINE_STATES = {
+        true:  {cls: 'running',  label: 'Engine running'},
+        false: {cls: 'stopped',  label: 'Engine not running'},
+        null:  {cls: 'unknown',  label: 'Engine status unknown'}
+    };
+
+    socket.on('engine_status', function(msg) {
+        var el = document.getElementById('engine-status');
+        if (!el) return;
+        var state = ENGINE_STATES[msg.running] || ENGINE_STATES[null];
+        el.className = 'engine-status ' + state.cls;
+        var label = el.querySelector('.engine-label');
+        if (label) label.textContent = state.label;
+    });
+
     socket.on('build_status', function(msg) {
         if (statusEl) {
             statusEl.className = 'status-indicator ' + msg.status;

--- a/standalone_update/web/static/style.css
+++ b/standalone_update/web/static/style.css
@@ -285,6 +285,9 @@ button[type="submit"]:hover {
 }
 
 .status-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
     margin-bottom: 0.75rem;
 }
 
@@ -504,6 +507,9 @@ h2 {
 }
 
 .log-panel-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
     margin-bottom: 0.5rem;
 }
 
@@ -566,6 +572,55 @@ h2 {
 .cfg-editor:focus {
     outline: 2px solid #3498db;
     outline-offset: -1px;
+}
+
+/* Engine process status badge */
+.engine-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-left: auto;
+}
+
+.engine-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.engine-status.running .engine-dot {
+    background: #27ae60;
+}
+
+.engine-status.running .engine-label {
+    color: #27ae60;
+}
+
+.engine-status.stopped .engine-dot {
+    background: #95a5a6;
+}
+
+.engine-status.stopped .engine-label {
+    color: #95a5a6;
+}
+
+.engine-status.stale .engine-dot {
+    background: #f39c12;
+}
+
+.engine-status.stale .engine-label {
+    color: #f39c12;
+}
+
+.engine-status.unknown .engine-dot {
+    background: #bdc3c7;
+}
+
+.engine-status.unknown .engine-label {
+    color: #bdc3c7;
 }
 
 /* WebSocket connection status */

--- a/standalone_update/web/templates/logs.html
+++ b/standalone_update/web/templates/logs.html
@@ -9,6 +9,10 @@
     <div class="log-panel-header">
         <span class="log-panel-name">{{ panel.name }}</span>
         <span class="log-panel-path">{{ panel.path | basename }}</span>
+        <span class="engine-status unknown" id="engine-status-{{ panel.id }}">
+            <span class="engine-dot"></span>
+            <span class="engine-label">Checking...</span>
+        </span>
     </div>
     {% if panel.error %}
     <p class="log-error">{{ panel.error }}</p>

--- a/standalone_update/web/templates/server.html
+++ b/standalone_update/web/templates/server.html
@@ -14,6 +14,10 @@
             {% elif status == 'stopping' %}Stopping...
             {% endif %}
         </span>
+        <span class="engine-status unknown" id="engine-status">
+            <span class="engine-dot"></span>
+            <span class="engine-label">Checking...</span>
+        </span>
     </div>
     <div class="button-row">
         <div>


### PR DESCRIPTION
Poll for the fs2_open process via pgrep and push engine running/stopped status to Build Controls and Game Logs pages over WebSocket. On the Game Logs page, a one-time lsof check at page load determines whether each log file is actively open by the engine, distinguishing "Log active" (green), "Engine running — log stale" (amber), and "Engine not running" (grey). Rename the logs WS status from "Live (connected)" to "Connected" to avoid confusion with the new engine indicator.