### PR TITLE
Hide Update & Restart button when no mod VCS is configured

### DIFF
--- a/standalone_update/web/static/server_ws.js
+++ b/standalone_update/web/static/server_ws.js
@@ -28,10 +28,11 @@
         });
     }
 
-    buttons[0].addEventListener('click', function() { doAction('rebuild'); });
-    buttons[1].addEventListener('click', function() { doAction('update'); });
-    buttons[2].addEventListener('click', function() { doAction('restart'); });
-    buttons[3].addEventListener('click', function() { doAction('stop'); });
+    buttons.forEach(function(btn, i) {
+        if (!btn) return;
+        var actions = ['rebuild', 'update', 'restart', 'stop'];
+        btn.addEventListener('click', function() { doAction(actions[i]); });
+    });
 
     socket.on('update_log_lines', function(msg) {
         if (!logEl) {

--- a/standalone_update/web/templates/server.html
+++ b/standalone_update/web/templates/server.html
@@ -25,11 +25,13 @@
                     {{ 'disabled' if is_running }}>Rebuild</button>
             <span class="btn-hint">Fetch, build, and deploy a new binary</span>
         </div>
+        {% if build_info.mod_vcs %}
         <div>
             <button type="button" class="btn btn-update" id="btn-update"
                     {{ 'disabled' if is_running }}>Update &amp; Restart</button>
             <span class="btn-hint">Update mod data and restart the server</span>
         </div>
+        {% endif %}
         <div>
             <button type="button" class="btn btn-restart" id="btn-restart"
                     {{ 'disabled' if is_running }}>Restart</button>


### PR DESCRIPTION
The button is not useful for servers without a mod/VCS setup, so hide it to avoid confusion.