### PR TITLE
Add engine webui proxy to wrap legacy game server management UI

### DIFF
--- a/standalone_update/web/requirements.txt
+++ b/standalone_update/web/requirements.txt
@@ -4,4 +4,5 @@ Flask-SocketIO>=5.3,<6
 Flask-WTF>=1.2,<2
 gevent>=24.0
 gunicorn>=21,<24
+requests>=2.28,<3
 simple-websocket>=1.0,<2

--- a/standalone_update/web/server.py
+++ b/standalone_update/web/server.py
@@ -7,7 +7,8 @@ import threading
 import shutil
 from datetime import datetime, timedelta
 
-from flask import Flask, render_template, request, redirect, url_for, flash
+import requests as http_requests
+from flask import Flask, make_response, render_template, request, redirect, url_for, flash
 from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required, current_user
 from flask_socketio import SocketIO, join_room
 from flask_wtf.csrf import CSRFProtect
@@ -33,6 +34,12 @@ app.config['MAX_CONTENT_LENGTH'] = 1 * 1024 * 1024  # 1 MB
 
 app.jinja_env.filters['basename'] = os.path.basename
 app.jinja_env.globals['APP_TITLE'] = APP_TITLE
+
+
+@app.context_processor
+def inject_engine_webui_flag():
+    """Make engine_webui_available accessible in all templates."""
+    return {'engine_webui_available': parse_multi_cfg_webapi() is not None}
 
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
@@ -161,6 +168,54 @@ def get_fso_data_file(filename):
     if mod_dirname:
         return os.path.join(fso_data, mod_dirname, 'data', filename)
     return os.path.join(fso_data, 'data', filename)
+
+
+def parse_multi_cfg_webapi():
+    """Parse multi.cfg for engine web API settings.
+
+    Returns a dict with 'port', 'username', and 'password' if the web API
+    appears to be configured (i.e. +webui_root is set), or None otherwise.
+    """
+    cfg_path = get_fso_data_file('multi.cfg')
+    if not os.path.exists(cfg_path):
+        return None
+
+    settings = {}
+    try:
+        with open(cfg_path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('+webapi_server_port'):
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        try:
+                            settings['port'] = int(parts[1])
+                        except ValueError:
+                            pass
+                elif line.startswith('+webapi_username'):
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        settings['username'] = parts[1]
+                elif line.startswith('+webapi_password'):
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        settings['password'] = parts[1]
+                elif line.startswith('+webui_root'):
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        settings['webui_root'] = parts[1]
+    except OSError:
+        return None
+
+    # Only expose the proxy when the engine web API is configured
+    if 'webui_root' not in settings:
+        return None
+
+    # Apply engine defaults for any missing values
+    settings.setdefault('port', 8080)
+    settings.setdefault('username', 'admin')
+    settings.setdefault('password', 'admin')
+    return settings
 
 
 def get_log_panels():
@@ -594,6 +649,93 @@ def game_logs():
                 _sync_watcher_to_offset(panel['path'], f.tell())
             panel['error'] = None
     return render_template('logs.html', panels=panels)
+
+
+# --- Engine web UI proxy ---
+# Forwards requests to the game engine's built-in Mongoose HTTP server,
+# injecting Basic Auth from multi.cfg so the user only authenticates once
+# through the Flask login.  Two route prefixes are needed because the legacy
+# JS uses a mix of relative URLs (resolve under /engine/) and absolute URLs
+# (resolve at /api/1/).
+
+_ENGINE_PROXY_TIMEOUT = 10  # seconds
+
+# Relaxed CSP for the legacy engine webui which relies on inline styles
+# (jQuery UI, DataTables) and may use eval (older jQuery/DataTables).
+_ENGINE_CSP = (
+    "default-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+    "connect-src 'self'; "
+    "img-src 'self'"
+)
+
+# External auto-login script tag injected into the legacy index.html so
+# users skip the built-in login form — our proxy handles authentication.
+_ENGINE_AUTOLOGIN_TAG = '<script src="/static/engine_autologin.js"></script>'
+
+
+def _proxy_to_engine(target_path):
+    """Forward the current request to the engine's web server."""
+    webapi = parse_multi_cfg_webapi()
+    if not webapi:
+        return make_response('Engine web API is not configured in multi.cfg.', 502)
+
+    url = f'http://127.0.0.1:{webapi["port"]}/{target_path}'
+    if request.query_string:
+        url += '?' + request.query_string.decode()
+
+    # Strip hop-by-hop and auth headers — we supply our own auth
+    fwd_headers = {k: v for k, v in request.headers
+                   if k.lower() not in ('host', 'authorization', 'cookie')}
+
+    try:
+        resp = http_requests.request(
+            method=request.method,
+            url=url,
+            data=request.get_data(),
+            headers=fwd_headers,
+            auth=(webapi['username'], webapi['password']),
+            allow_redirects=False,
+            timeout=_ENGINE_PROXY_TIMEOUT,
+        )
+    except http_requests.ConnectionError:
+        return make_response('Engine web server is not reachable.', 502)
+    except http_requests.Timeout:
+        return make_response('Engine web server timed out.', 504)
+
+    # Pass through the response, stripping hop-by-hop headers
+    excluded = {'content-encoding', 'transfer-encoding', 'connection'}
+    headers = {k: v for k, v in resp.headers.items()
+               if k.lower() not in excluded}
+
+    body = resp.content
+
+    # For the legacy HTML page: inject auto-login and set a relaxed CSP
+    if target_path in ('', 'index.html') and resp.status_code == 200:
+        text = resp.text
+        text = text.replace('</body>', _ENGINE_AUTOLOGIN_TAG + '\n</body>')
+        response = make_response(text, resp.status_code, headers)
+        response.headers['Content-Security-Policy'] = _ENGINE_CSP
+        return response
+
+    return make_response(body, resp.status_code, headers)
+
+
+@app.route('/engine/')
+@app.route('/engine/<path:subpath>', methods=['GET', 'POST', 'PUT', 'DELETE'])
+@login_required
+@csrf.exempt
+def engine_proxy(subpath=''):
+    return _proxy_to_engine(subpath)
+
+
+@app.route('/api/1/', methods=['GET', 'POST', 'PUT', 'DELETE'])
+@app.route('/api/1/<path:subpath>', methods=['GET', 'POST', 'PUT', 'DELETE'])
+@login_required
+@csrf.exempt
+def engine_api_proxy(subpath=''):
+    return _proxy_to_engine(f'api/1/{subpath}')
 
 
 if __name__ == '__main__':

--- a/standalone_update/web/standalone-update-web.nginx.conf.example
+++ b/standalone_update/web/standalone-update-web.nginx.conf.example
@@ -49,6 +49,41 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Engine webui proxy — relaxed CSP for legacy jQuery UI which uses
+    # inline event handlers (DataTables onclick), inline styles, and
+    # possibly eval (older jQuery/DataTables).  Flask also sets this CSP
+    # on the HTML response for direct-access (no-nginx) scenarios;
+    # proxy_hide_header prevents the browser from seeing two competing
+    # policies (it would apply the stricter of the two).
+    # Location-level add_header replaces server-level, so all security
+    # headers must be repeated here.
+    location /engine/ {
+        limit_req zone=standalone_update_general burst=40 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_hide_header Content-Security-Policy;
+
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+        add_header Referrer-Policy strict-origin-when-cross-origin;
+        add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; img-src 'self'";
+    }
+
+    # Engine API proxy — absolute-path AJAX calls from the legacy webui
+    # (e.g. /api/1/player) land here instead of location /.  Shares the
+    # higher burst with /engine/ since they fire together on page load.
+    location /api/1/ {
+        limit_req zone=standalone_update_general burst=40 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Tight rate limit on login POST only
     location = /login {
         limit_req zone=standalone_update_login burst=5 nodelay;

--- a/standalone_update/web/static/engine_autologin.js
+++ b/standalone_update/web/static/engine_autologin.js
@@ -1,0 +1,14 @@
+// Auto-authenticate to the legacy engine webui.
+// The Flask proxy injects real Basic Auth credentials on every request,
+// so the actual values passed here don't matter — we just need to trigger
+// the login event so jQuery UI enables all tabs.
+//
+// This script loads after main.js, so our login handler fires after
+// main.js's handler (which enables all tabs), letting us safely switch
+// to the Server tab as the default landing page.
+$(document).ready(function () {
+    webui.events.subscribe('login', function () {
+        $('#tabContainer').tabs('option', 'active', 1);
+    });
+    webui.auth.do('proxy', 'proxy');
+});

--- a/standalone_update/web/templates/base.html
+++ b/standalone_update/web/templates/base.html
@@ -24,6 +24,10 @@
                {% if request.endpoint in ('game_config', 'game_config_save') %}class="active"{% endif %}>Game Config</a>
             <a href="{{ url_for('game_logs') }}"
                {% if request.endpoint == 'game_logs' %}class="active"{% endif %}>Game Logs</a>
+            {% if engine_webui_available %}
+            <a href="{{ url_for('engine_proxy') }}"
+               {% if request.endpoint in ('engine_proxy', 'engine_api_proxy') %}class="active"{% endif %}>Engine</a>
+            {% endif %}
             {% if current_user.is_authenticated %}
             <form method="post" action="{{ url_for('logout') }}" class="nav-logout">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
Proxies the fs2_open engine's built-in Mongoose web server through Flask, providing SSL termination and single-login authentication. Reads webapi credentials and port directly from multi.cfg (the same file the Game Config page already edits), so there's no config duplication.

- Parse multi.cfg for +webui_root, +webapi_username, +webapi_password, +webapi_server_port to configure the proxy connection
- Add /engine/ and /api/1/ proxy routes (both @login_required, CSRF-exempt) to handle the legacy JS's mix of relative and absolute AJAX URLs
- Inject external auto-login script that bypasses the legacy login form and lands on the Server tab automatically
- Set relaxed CSP on proxied HTML for legacy jQuery UI inline styles/scripts
- Conditionally show Engine nav link only when +webui_root is configured
- Update nginx example config with /engine/ and /api/1/ location blocks (higher burst limit for initial SPA asset load, proxy_hide_header to prevent duplicate CSP policies)