### PR TITLE
Fix engine detection and stop in debugger mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ fsobuild/data
 **/.cache
 
 state.pickle
+
+# Spot for venv files when testing locally
+.venv

--- a/standalone_update/update
+++ b/standalone_update/update
@@ -102,28 +102,48 @@ error_exit() {
     exit 1
 }
 
+_kill_and_wait() {
+    local _name="$1"
+    if ! pgrep "${_name}" > /dev/null 2>&1; then
+        return
+    fi
+    echo "Killing ${_name}..."
+    pkill "${_name}" || error_exit "Could not kill ${_name}"
+    # Wait for the process to fully exit so it releases log files, sockets, etc.
+    local _tries=0
+    while pgrep "${_name}" > /dev/null 2>&1; do
+        sleep 0.25
+        _tries=$((_tries + 1))
+        if [ $_tries -ge 20 ]; then
+            echo "${_name} still running after 5s, sending SIGKILL..."
+            pkill -9 "${_name}" 2>/dev/null
+            sleep 0.5
+            break
+        fi
+    done
+}
+
 stop_server() {
     echo "Stopping server..."
-    if pgrep "${MAIN_PROCESS}" > /dev/null 2>&1; then
-        echo "Killing ${MAIN_PROCESS}..."
-        pkill "${MAIN_PROCESS}" || error_exit "Could not kill ${MAIN_PROCESS}"
-        # Wait for process to fully exit so it releases log files, sockets, etc.
-        local _tries=0
-        while pgrep "${MAIN_PROCESS}" > /dev/null 2>&1; do
-            sleep 0.25
-            _tries=$((_tries + 1))
-            if [ $_tries -ge 20 ]; then
-                echo "Process still running after 5s, sending SIGKILL..."
-                pkill -9 "${MAIN_PROCESS}" 2>/dev/null
-                sleep 0.5
-                break
-            fi
-        done
+    # In debugger mode, kill the debugger first so the inferior is no longer
+    # traced. lldb on detach typically leaves the inferior in a stopped (T)
+    # state, so SIGCONT it back to running — then SIGTERM hits SDL's signal
+    # handler, which converts it to SDL_QUIT and lets the engine flush its
+    # log files on shutdown. _kill_and_wait's SIGKILL fallback still catches
+    # a hung main loop.
+    if [ -n "${USE_DEBUGGER}" ]; then
+        _kill_and_wait "${DEBUGGER}"
+        pkill -CONT fs2_open 2>/dev/null || true
     fi
-    if screen -ls | grep server > /dev/null; then
+    _kill_and_wait "fs2_open"
+    # Best-effort screen cleanup — by now the screen child has usually
+    # exited, so the session may already be gone or in a dead state.
+    if screen -ls 2>/dev/null | grep -q '\.server\b'; then
         echo "Killing screen..."
-        screen -S server -X quit || error_exit "Could not kill screen"
+        screen -S server -X quit 2>/dev/null || true
     fi
+    # Sweep up any dead sockets so future starts don't trip on them.
+    screen -wipe > /dev/null 2>&1 || true
 }
 
 start_server() {

--- a/standalone_update/web/server.py
+++ b/standalone_update/web/server.py
@@ -465,19 +465,26 @@ def read_build_info():
 
 
 def _get_engine_process_name():
-    """Determine the process name to look for (fs2_open, or debugger if USE_DEBUGGER is set)."""
+    """Determine the process name to look for.
+
+    Mirrors the update script: USE_DEBUGGER unset → fs2_open;
+    set + COMPILER=clang → lldb; set + anything else → gdb.
+    """
     overrides = parse_env(ENV_PATH)
     use_debugger = overrides.get('USE_DEBUGGER', '')
-    if not use_debugger:
-        # Check .env.default — USE_DEBUGGER is commented out by default,
-        # so parse_env_default won't return a value unless it's uncommented
+    compiler = overrides.get('COMPILER', '')
+    # Fall back to .env.default for any value not overridden. USE_DEBUGGER is
+    # commented out by default, so parse_env_default won't return it unless
+    # it's been uncommented; COMPILER has a default ('gcc').
+    if not use_debugger or not compiler:
         for var in parse_env_default(ENV_DEFAULT_PATH):
-            if var.name == 'USE_DEBUGGER' and var.default_value:
+            if not use_debugger and var.name == 'USE_DEBUGGER' and var.default_value:
                 use_debugger = var.default_value
-                break
-    if use_debugger:
-        return 'lldb' if sys.platform == 'darwin' else 'gdb'
-    return 'fs2_open'
+            elif not compiler and var.name == 'COMPILER' and var.default_value:
+                compiler = var.default_value
+    if not use_debugger:
+        return 'fs2_open'
+    return 'lldb' if compiler == 'clang' else 'gdb'
 
 
 def is_engine_running():


### PR DESCRIPTION
## Summary

Two bugs in the standalone update flow when running the engine under a debugger, plus a `.gitignore` add.

**Engine detection (web UI):** `_get_engine_process_name` chose between `gdb` and `lldb` by `sys.platform`, but the `update` script picks the debugger by `COMPILER`. On Linux + `clang` (e.g. low-RAM hosts that can only build with clang) the UI looked for `gdb` while update launched `lldb`, so the engine-running websocket indicator and the log-active lsof badge silently misreported even with a server visibly running on PXO. Now mirrors `update`'s logic: `clang` -> `lldb`, anything else -> `gdb`.

**`stop_server` in debugger mode:** Only the debugger was killed (`MAIN_PROCESS=lldb`/`gdb`), orphaning `fs2_open` under launchd/init where it kept holding the network port. The next start then failed with a resource conflict.

Now in debugger mode:
1. Kill the debugger first so the inferior is no longer traced.
2. `SIGCONT` `fs2_open` in case lldb's detach left it stopped (T state on macOS).
3. `SIGTERM` `fs2_open` so SDL's signal handler can convert it to `SDL_QUIT` and let the engine flush its log files on shutdown.
4. `_kill_and_wait`'s 5s SIGKILL fallback still catches a hung main loop.

Also factored the kill-and-wait dance into `_kill_and_wait`, made the screen cleanup best-effort (the screen child is usually already gone, and `error_exit` on a missing session was breaking otherwise-successful stops), tightened the grep to `\.server\b`, and added `screen -wipe` to clear stale dead sockets.

**`.gitignore`:** add `.venv` for local testing virtualenvs.

## Test plan

- [x] macOS, clang, debug build, no debugger -- start/stop/restart cycle, log closes cleanly
- [x] macOS, clang, debug build, with lldb -- start/stop/restart cycle, no orphan, no 5s hangup, log closes cleanly
- [x] macOS, clang, fastdebug build -- start/stop/restart cycle
- [x] Linux, gcc, no debugger -- regression check, behavior unchanged
- [x] Linux, gcc, with gdb -- start/stop/restart cycle
- [x] Linux, clang, with lldb (the original reported gap) -- engine-running indicator, log-active badge, and stop cycle all correct