### PR TITLE
Drive standalone stop cleanup from live process state

### DIFF
--- a/standalone_update/update
+++ b/standalone_update/update
@@ -103,47 +103,149 @@ error_exit() {
 }
 
 _kill_and_wait() {
-    local _name="$1"
-    if ! pgrep "${_name}" > /dev/null 2>&1; then
+    # Args: pattern [pgrep-flag] [label]
+    # pattern: pgrep pattern (matches process name by default)
+    # pgrep-flag: pass "-f" to match against full command line (argv)
+    # label: human-friendly name for output (defaults to pattern)
+    local _pattern="$1"
+    local _flag="${2:-}"
+    local _label="${3:-${_pattern}}"
+    if ! pgrep ${_flag} "${_pattern}" > /dev/null 2>&1; then
         return
     fi
-    echo "Killing ${_name}..."
-    pkill "${_name}" || error_exit "Could not kill ${_name}"
+    echo "Killing ${_label}..."
+    pkill ${_flag} "${_pattern}" 2>/dev/null || true
     # Wait for the process to fully exit so it releases log files, sockets, etc.
     local _tries=0
-    while pgrep "${_name}" > /dev/null 2>&1; do
+    while pgrep ${_flag} "${_pattern}" > /dev/null 2>&1; do
         sleep 0.25
         _tries=$((_tries + 1))
         if [ $_tries -ge 20 ]; then
-            echo "${_name} still running after 5s, sending SIGKILL..."
-            pkill -9 "${_name}" 2>/dev/null
+            echo "${_label} still running after 5s, sending SIGKILL..."
+            pkill -9 ${_flag} "${_pattern}" 2>/dev/null
             sleep 0.5
             break
         fi
     done
 }
 
+_kill_pid() {
+    local _pid="$1"
+    local _label="${2:-PID ${_pid}}"
+    [ -z "${_pid}" ] && return
+    if ! kill -0 "${_pid}" 2>/dev/null; then
+        return
+    fi
+    echo "Killing ${_label}..."
+    kill "${_pid}" 2>/dev/null || true
+    local _tries=0
+    while kill -0 "${_pid}" 2>/dev/null; do
+        sleep 0.25
+        _tries=$((_tries + 1))
+        if [ $_tries -ge 20 ]; then
+            echo "${_label} still running after 5s, sending SIGKILL..."
+            kill -9 "${_pid}" 2>/dev/null
+            sleep 0.5
+            break
+        fi
+    done
+}
+
+# Walk up the process tree from a PID, emitting "PPID:comm" lines for
+# every ancestor that looks like a debugger. On macOS lldb spawns
+# debugserver as the direct tracer of the inferior, so we have to walk
+# past it to find lldb itself. Stops at session wrappers (screen, login,
+# launchd, init/systemd) or PID 1.
+_find_debugger_ancestors() {
+    local _pid="$1"
+    local _max=10
+    while [ ${_max} -gt 0 ]; do
+        local _ppid
+        _ppid=$(ps -o ppid= -p "${_pid}" 2>/dev/null | tr -d ' ')
+        [ -z "${_ppid}" ] && return
+        [ "${_ppid}" = "0" ] && return
+        [ "${_ppid}" = "1" ] && return
+        local _pname
+        _pname=$(ps -o comm= -p "${_ppid}" 2>/dev/null | sed 's:.*/::')
+        case "${_pname}" in
+            lldb|gdb|debugserver|lldb-server)
+                echo "${_ppid}:${_pname}"
+                ;;
+            SCREEN|screen|login|launchd|init|systemd)
+                return
+                ;;
+        esac
+        _pid="${_ppid}"
+        _max=$((_max - 1))
+    done
+}
+
 stop_server() {
     echo "Stopping server..."
-    # In debugger mode, kill the debugger first so the inferior is no longer
-    # traced. lldb on detach typically leaves the inferior in a stopped (T)
-    # state, so SIGCONT it back to running — then SIGTERM hits SDL's signal
-    # handler, which converts it to SDL_QUIT and lets the engine flush its
-    # log files on shutdown. _kill_and_wait's SIGKILL fallback still catches
-    # a hung main loop.
-    if [ -n "${USE_DEBUGGER}" ]; then
-        _kill_and_wait "${DEBUGGER}"
-        pkill -CONT fs2_open 2>/dev/null || true
-    fi
-    _kill_and_wait "fs2_open"
-    # Best-effort screen cleanup — by now the screen child has usually
-    # exited, so the session may already be gone or in a dead state.
+
+    # Cleanup is driven by live process state, not .env — the deployed
+    # configuration may disagree (manual launches, toggled debugger
+    # between start and stop). Thoroughness matters more than precision.
+    #
+    # Restrict every match to processes whose argv contains -standalone,
+    # so a client fs2_open (or its debugger) running alongside on a dev
+    # machine is left alone — only the server has -standalone.
+    local _standalone='fs2_open.*-standalone'
+
+    # Walk up the process tree from each standalone fs2_open looking for
+    # debugger ancestors and kill them. We have to walk (not just check
+    # the direct parent) because on macOS lldb spawns debugserver as the
+    # actual tracer, so the chain is fs2_open <- debugserver <- lldb <-
+    # login <- SCREEN. Killing by PID — not by name — keeps unrelated
+    # lldb/gdb instances on dev machines safe.
+    # pgrep -f for the engine pattern can also return the debugger's PID
+    # (its argv mentions the standalone binary), so we filter on process
+    # name to keep only fs2_open candidates to walk up from.
+    local _engine_pid _pname _killed_debugger=0
+    for _engine_pid in $(pgrep -f "${_standalone}" 2>/dev/null); do
+        _pname=$(ps -o comm= -p "${_engine_pid}" 2>/dev/null | sed 's:.*/::')
+        case "${_pname}" in fs2_open*) ;; *) continue ;; esac
+        local _entry _anc_pid _anc_name
+        for _entry in $(_find_debugger_ancestors "${_engine_pid}"); do
+            _anc_pid="${_entry%:*}"
+            _anc_name="${_entry#*:}"
+            _kill_pid "${_anc_pid}" "${_anc_name} (PID ${_anc_pid}, ancestor of standalone fs2_open)"
+            _killed_debugger=1
+        done
+    done
+
+    # SIGCONT in case the debugger left the inferior in a stopped (T) state.
+    [ ${_killed_debugger} -eq 1 ] && pkill -CONT -f "${_standalone}" 2>/dev/null || true
+
+    # Graceful shutdown: SDL hooks SIGTERM into an SDL_QUIT event so the
+    # engine can flush its log files. SIGKILL is the 5s fallback.
+    _kill_and_wait "${_standalone}" '-f' 'fs2_open (standalone)'
+
+    # Tear down the "server" screen session — this also SIGHUPs any
+    # leftover children running inside it (e.g. an orphaned debugger
+    # whose inferior already exited).
     if screen -ls 2>/dev/null | grep -q '\.server\b'; then
         echo "Killing screen..."
         screen -S server -X quit 2>/dev/null || true
     fi
-    # Sweep up any dead sockets so future starts don't trip on them.
+    # Wipe any dead session metadata so the next start doesn't trip on it.
     screen -wipe > /dev/null 2>&1 || true
+
+    # Catch debuggers that got reparented under init/launchd when their
+    # screen died (so screen -X quit can't reach them). Match by argv —
+    # debuggers we launched always have -standalone in their command line
+    # (passed as the run-arguments to lldb/gdb), so a debugger attached
+    # to a client isn't touched.
+    _kill_and_wait 'lldb.*-standalone' '-f' 'orphaned lldb (standalone)'
+    _kill_and_wait 'gdb.*-standalone' '-f' 'orphaned gdb (standalone)'
+
+    # Final verification — anything standalone-shaped still alive gets
+    # force-killed. We don't fail the operation.
+    if pgrep -f "${_standalone}" > /dev/null 2>&1; then
+        echo "Standalone fs2_open still present after cleanup; sending SIGKILL"
+        pkill -9 -f "${_standalone}" 2>/dev/null
+        sleep 0.5
+    fi
 }
 
 start_server() {

--- a/standalone_update/web/server.py
+++ b/standalone_update/web/server.py
@@ -464,38 +464,21 @@ def read_build_info():
         return None
 
 
-def _get_engine_process_name():
-    """Determine the process name to look for.
-
-    Mirrors the update script: USE_DEBUGGER unset → fs2_open;
-    set + COMPILER=clang → lldb; set + anything else → gdb.
-    """
-    overrides = parse_env(ENV_PATH)
-    use_debugger = overrides.get('USE_DEBUGGER', '')
-    compiler = overrides.get('COMPILER', '')
-    # Fall back to .env.default for any value not overridden. USE_DEBUGGER is
-    # commented out by default, so parse_env_default won't return it unless
-    # it's been uncommented; COMPILER has a default ('gcc').
-    if not use_debugger or not compiler:
-        for var in parse_env_default(ENV_DEFAULT_PATH):
-            if not use_debugger and var.name == 'USE_DEBUGGER' and var.default_value:
-                use_debugger = var.default_value
-            elif not compiler and var.name == 'COMPILER' and var.default_value:
-                compiler = var.default_value
-    if not use_debugger:
-        return 'fs2_open'
-    return 'lldb' if compiler == 'clang' else 'gdb'
-
-
 def is_engine_running():
-    """Check whether the game engine process is currently running."""
-    process_name = _get_engine_process_name()
+    """Check whether the standalone game engine is currently running.
+
+    Filters on argv via `pgrep -f` so only fs2_open instances launched
+    with -standalone match — a client running alongside on a dev machine
+    isn't reported as the engine. Looks at live process state rather
+    than .env-derived configuration so a toggled USE_DEBUGGER/COMPILER
+    between starts doesn't misreport.
+    """
     pgrep = shutil.which('pgrep')
     if not pgrep:
         return None  # Can't determine
     try:
         result = subprocess.run(
-            [pgrep, process_name],
+            [pgrep, '-f', 'fs2_open.*-standalone'],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
         )
         return result.returncode == 0
@@ -504,16 +487,15 @@ def is_engine_running():
 
 
 def is_log_open_by_engine(filepath):
-    """Check whether the engine process currently has a specific log file open."""
+    """Check whether fs2_open currently has a specific log file open."""
     if not filepath or not os.path.exists(filepath):
         return False
-    process_name = _get_engine_process_name()
     lsof = shutil.which('lsof')
     if not lsof:
         return None  # Can't determine
     try:
         result = subprocess.run(
-            [lsof, '-c', process_name, '--', filepath],
+            [lsof, '-c', 'fs2_open', '--', filepath],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
         )
         return result.returncode == 0


### PR DESCRIPTION
Builds on #115 to make `stop_server` robust against three failure modes that `.env`-driven detection couldn't handle:

1. **`.env` can disagree with the running deployment.** Toggling `USE_DEBUGGER` off between start and stop made `stop_server` miss the still-attached debugger, hang 5s on SIGTERM, and orphan it. Manual screen launches were equally invisible.
2. **A dev machine may run a client `fs2_open` alongside the server** on different ports. The `.env` path would also kill the client.
3. **On macOS, lldb spawns `debugserver` as the actual ptrace tracer.** `fs2_open`'s direct parent is `debugserver`, not `lldb`. Checking only the direct parent for `lldb`/`gdb` misses macOS entirely.

## Rework

- `pgrep -f 'fs2_open.*-standalone'` to find the engine. The `-standalone` filter is applied to every subsequent `pgrep`/`pkill` so a client `fs2_open` and any debugger attached to it stay untouched.
- Walk the process tree up from `fs2_open` and kill every ancestor that looks like a debugger (`lldb`, `gdb`, `debugserver`, `lldb-server`). Stops at session wrappers (`SCREEN`/`login`/`launchd`/`init`/`systemd`) or PID 1. Killing by PID -- not by name -- keeps unrelated `lldb`/`gdb` instances on dev machines safe.
- `SIGCONT` the inferior before `SIGTERM` (debugger detach may leave it in a stopped (T) state).
- `screen -X quit` + `screen -wipe` for the session itself, also HUPing anything left inside it.
- Argv-based sweep (`'lldb.*-standalone'`, `'gdb.*-standalone'`) catches reparented orphan debuggers from prior runs.
- Final verification `SIGKILL`s anything standalone-shaped that's still alive.

`_kill_and_wait` now takes an optional `pgrep`-flag arg (used to match by argv pattern) and is tolerant of `pkill` failure; the verification step is the safety net. New helpers: `_kill_pid` for PID-targeted kills, `_find_debugger_ancestors` for the tree walk.

Web UI `is_engine_running` drops the `.env`-derived process-name lookup and uses the same `pgrep -f` filter, so the indicator doesn't light up for a client `fs2_open` running alongside the server on a dev machine.

## Test plan

- [x] macOS, clang, debug build, no debugger -- start/stop/restart, log closes cleanly via `SDL_QUIT`.
- [x] macOS, clang, debug build, with lldb -- ancestor walk identifies both `debugserver` and `lldb`; stop is ~2s with no orphan tail.
- [x] macOS, clang, fastdebug build.
- [x] macOS toggle case -- start with `USE_DEBUGGER=yes`, uncheck in build config, hit Stop. Identifies lldb regardless of `.env`.
- [x] macOS dev machine paranoia -- run an unrelated `lldb` session in a separate terminal, then start/stop the standalone server. Unrelated lldb should be untouched.
- [x] macOS dev machine, client + server alongside -- run a client `fs2_open` (no `-standalone`) on different ports, then start/stop the standalone. Client should be untouched and the UI should not report \"engine running\" when only the client is up.
- [x] Linux, gcc, no debugger -- regression check.
- [x] Linux, gcc, with gdb -- start/stop/restart cycle (gdb is direct parent, no `debugserver` intermediary).
- [x] Linux, clang, with lldb (the originally reported gap) -- engine-running indicator, log-active badge, and stop cycle all correct.
- [x] Stale screen session cleanup -- manually `screen -dmS server sleep 9999`, then run `update -S`. Should be reliably torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)